### PR TITLE
feat: Spiellogik als game-Modul ins Frontend übertragen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,14 @@ jobs:
       - name: Build
         run: ./gradlew assembleDebug
 
-      - name: Run Unit Tests
+      - name: Run Game Logic Tests
+        run: ./gradlew :game:test
+
+      - name: Run App Unit Tests
         run: ./gradlew testDebugUnitTest
 
       - name: Generate Coverage Report
-        run: ./gradlew jacocoTestReport
+        run: ./gradlew :game:jacocoTestReport jacocoTestReport
 
       - name: Run Lint
         run: ./gradlew lintDebug

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -141,6 +141,10 @@ dependencies {
     // Game logic
     implementation(project(":game"))
 
+    // ViewModel
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
+
     // WebSocket
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.java-websocket:Java-WebSocket:1.5.6")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -138,6 +138,9 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:$navigationComposeVersion")
     debugImplementation("androidx.compose.ui:ui-tooling")
 
+    // Game logic
+    implementation(project(":game"))
+
     // WebSocket
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.java-websocket:Java-WebSocket:1.5.6")

--- a/app/src/main/kotlin/at/aau/se2/skyjo/MainActivity.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/MainActivity.kt
@@ -3,18 +3,22 @@ package at.aau.se2.skyjo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.navigation.compose.rememberNavController
+import at.aau.se2.skyjo.ui.game.GameViewModel
 import at.aau.se2.skyjo.ui.navigation.AppNavHost
 import at.aau.se2.skyjo.ui.theme.SkyjoTheme
 
 class MainActivity : ComponentActivity() {
+
+    private val gameViewModel: GameViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             SkyjoTheme {
                 val navController = rememberNavController()
-                AppNavHost(navController = navController)
+                AppNavHost(navController = navController, gameViewModel = gameViewModel)
             }
         }
     }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/game/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/game/GameViewModel.kt
@@ -1,0 +1,48 @@
+package at.aau.se2.skyjo.ui.game
+
+import androidx.lifecycle.ViewModel
+import at.aau.se2.skyjo.game.model.BoardPosition
+import at.aau.se2.skyjo.game.model.GameState
+import at.aau.se2.skyjo.game.service.SkyjoEngine
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class GameViewModel : ViewModel() {
+
+    private val engine = SkyjoEngine()
+
+    private val _state = MutableStateFlow<GameState?>(null)
+    val state: StateFlow<GameState?> = _state.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    fun startGame(playerNames: List<String>) {
+        val initialReveals = playerNames.associateWith {
+            setOf(BoardPosition(0, 0), BoardPosition(0, 1))
+        }
+        _state.value = engine.startGame(playerNames, initialReveals)
+    }
+
+    fun drawFromDeck() = runAction { engine.drawFromDeck(it) }
+
+    fun takeDiscardCard() = runAction { engine.takeDiscardCard(it) }
+
+    fun replaceDrawnCard(position: BoardPosition) = runAction { engine.replaceDrawnCard(it, position) }
+
+    fun discardAndReveal(position: BoardPosition) = runAction { engine.discardDrawnCardAndReveal(it, position) }
+
+    fun clearError() {
+        _error.value = null
+    }
+
+    private fun runAction(action: (GameState) -> GameState) {
+        val current = _state.value ?: return
+        try {
+            _state.value = action(current)
+        } catch (e: Exception) {
+            _error.value = e.message
+        }
+    }
+}

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
@@ -1,10 +1,13 @@
 package at.aau.se2.skyjo.ui.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import at.aau.se2.skyjo.ui.game.GameViewModel
 import at.aau.se2.skyjo.ui.screens.friends.FriendsScreen
 import at.aau.se2.skyjo.ui.screens.game.GameScreen
 import at.aau.se2.skyjo.ui.screens.lobby.LobbyScreen
@@ -14,8 +17,11 @@ import at.aau.se2.skyjo.ui.screens.start.StartScreen
 @Composable
 fun AppNavHost(
     navController: NavHostController,
+    gameViewModel: GameViewModel,
     modifier: Modifier = Modifier,
 ) {
+    val gameState by gameViewModel.state.collectAsState()
+
     val navigateMain: (AppDestination) -> Unit = { dest ->
         navController.navigate(dest.route) {
             popUpTo(AppDestination.Start.route) { saveState = true }
@@ -37,12 +43,20 @@ fun AppNavHost(
         }
         composable(AppDestination.Lobby.route) {
             LobbyScreen(
+                gameViewModel = gameViewModel,
                 onStartGame = { navController.navigate(AppDestination.Game.route) },
                 onBack = { navController.popBackStack() },
             )
         }
         composable(AppDestination.Game.route) {
-            GameScreen(onBack = { navController.popBackStack() })
+            GameScreen(
+                gameState = gameState,
+                onDrawFromDeck = { gameViewModel.drawFromDeck() },
+                onTakeDiscardCard = { gameViewModel.takeDiscardCard() },
+                onReplaceDrawnCard = { pos -> gameViewModel.replaceDrawnCard(pos) },
+                onDiscardAndReveal = { pos -> gameViewModel.discardAndReveal(pos) },
+                onBack = { navController.popBackStack() },
+            )
         }
         composable(AppDestination.Friends.route) {
             FriendsScreen(onNavigate = navigateMain)

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
@@ -2,6 +2,7 @@ package at.aau.se2.skyjo.ui.screens.game
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,26 +16,35 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import at.aau.se2.skyjo.game.model.BoardLayout
+import at.aau.se2.skyjo.game.model.BoardPosition
+import at.aau.se2.skyjo.game.model.BoardSlot
+import at.aau.se2.skyjo.game.model.GamePhase
+import at.aau.se2.skyjo.game.model.GameState
 import at.aau.se2.skyjo.ui.components.PrimaryButton
 import at.aau.se2.skyjo.ui.components.SecondaryButton
 import at.aau.se2.skyjo.ui.components.StatChip
@@ -53,42 +63,31 @@ import at.aau.se2.skyjo.ui.theme.PrimaryGreen
 import at.aau.se2.skyjo.ui.theme.SkyjoTheme
 import at.aau.se2.skyjo.ui.theme.SurfaceWhite
 
-// ── Dummy data ──────────────────────────────────────────────────────────────
-
-private data class GamePlayer(val name: String, val score: Int, val isActive: Boolean = false)
-
-private val dummyPlayers = listOf(
-    GamePlayer("Alice", 12, isActive = true),
-    GamePlayer("Bob", 8),
-    GamePlayer("Charlie", 15),
-)
-
-// Grid: null = face-down, number string = revealed
-private val myGrid = listOf(
-    listOf(null, "3", null, "-1"),
-    listOf("7", null, "11", null),
-    listOf(null, "5", null, "2"),
-)
-
-private val actionCards = listOf("👁 Peek", "🔄 Trade", "⚡ Double")
-
-// ── Screen ──────────────────────────────────────────────────────────────────
+private enum class PendingAction { PLACE_CARD, DISCARD_AND_REVEAL }
 
 @Composable
 fun GameScreen(
+    gameState: GameState?,
+    onDrawFromDeck: () -> Unit = {},
+    onTakeDiscardCard: () -> Unit = {},
+    onReplaceDrawnCard: (BoardPosition) -> Unit = {},
+    onDiscardAndReveal: (BoardPosition) -> Unit = {},
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var pendingAction by remember(gameState?.phase) { mutableStateOf<PendingAction?>(null) }
+    var showResults by remember(gameState?.phase) { mutableStateOf(gameState?.phase == GamePhase.ROUND_FINISHED) }
+
+    val currentPlayer = gameState?.players?.getOrNull(gameState.currentPlayerIndex)
+    val currentPlayerName = currentPlayer?.id ?: "—"
+
     Column(
         modifier = modifier
             .fillMaxSize()
             .background(BackgroundGray),
     ) {
         // ── Header ───────────────────────────────────────────────────────
-        Surface(
-            color = SurfaceWhite,
-            shadowElevation = 2.dp,
-        ) {
+        Surface(color = SurfaceWhite, shadowElevation = 2.dp) {
             Column {
                 Row(
                     modifier = Modifier
@@ -111,23 +110,38 @@ fun GameScreen(
                         color = PrimaryGreen,
                         modifier = Modifier.weight(1f),
                     )
-                    Text(
-                        text = "Round 1",
-                        style = MaterialTheme.typography.labelLarge,
-                        color = MutedText,
-                        modifier = Modifier.padding(end = 16.dp),
-                    )
+                    if (gameState?.phase == GamePhase.FINAL_TURNS) {
+                        Surface(
+                            shape = MaterialTheme.shapes.extraLarge,
+                            color = BlueSurface,
+                        ) {
+                            Text(
+                                text = "Final Turns: ${gameState.finalTurnsRemaining}",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
                 }
 
                 // Player pills
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 6.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    dummyPlayers.forEach { player ->
-                        PlayerPill(player = player, modifier = Modifier.weight(1f))
+                if (gameState != null) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 6.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        gameState.players.forEachIndexed { index, player ->
+                            PlayerPill(
+                                name = player.id,
+                                score = player.board.rawScore(),
+                                isActive = index == gameState.currentPlayerIndex,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
                     }
                 }
 
@@ -136,9 +150,25 @@ fun GameScreen(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    StatChip(label = "Turn", value = "Alice")
-                    StatChip(label = "Target", value = "≤ 100")
-                    StatChip(label = "Cards", value = "24 left")
+                    StatChip(label = "Turn", value = currentPlayerName)
+                    StatChip(label = "Deck", value = "${gameState?.drawPile?.size ?: "—"}")
+                    if (pendingAction != null) {
+                        Surface(
+                            shape = MaterialTheme.shapes.extraLarge,
+                            color = PrimaryGreen,
+                        ) {
+                            Text(
+                                text = when (pendingAction) {
+                                    PendingAction.PLACE_CARD -> "Tap a card to place"
+                                    PendingAction.DISCARD_AND_REVEAL -> "Tap a face-down card"
+                                    null -> ""
+                                },
+                                style = MaterialTheme.typography.labelSmall,
+                                color = SurfaceWhite,
+                                modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -150,96 +180,193 @@ fun GameScreen(
                 .padding(horizontal = 16.dp, vertical = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            // ── Action Market ─────────────────────────────────────────────
-            ActionMarketSection()
-
             // ── Deck + Discard ────────────────────────────────────────────
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                DeckCard(label = "Draw Deck", modifier = Modifier.weight(1f))
-                DiscardCard(value = "4", label = "Discard Pile", modifier = Modifier.weight(1f))
-            }
-
-            // ── Player Grid ───────────────────────────────────────────────
-            Surface(
-                shape = MaterialTheme.shapes.large,
-                color = SurfaceWhite,
-                shadowElevation = 2.dp,
-            ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = "Your Grid",
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                        )
-                        Surface(
-                            shape = MaterialTheme.shapes.extraLarge,
-                            color = GreenSurface,
-                        ) {
-                            Text(
-                                text = "Score: 12",
-                                style = MaterialTheme.typography.labelMedium,
-                                color = PrimaryGreen,
-                                fontWeight = FontWeight.Bold,
-                                modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
-                            )
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(12.dp))
-                    CardGrid(cards = myGrid)
+                DeckCard(
+                    size = gameState?.drawPile?.size,
+                    label = "Draw Deck",
+                    modifier = Modifier.weight(1f),
+                )
+                DiscardCard(
+                    value = gameState?.discardPile?.cards?.lastOrNull()?.value?.toString() ?: "—",
+                    label = "Discard Pile",
+                    modifier = Modifier.weight(1f),
+                )
+                if (gameState?.drawnCard != null) {
+                    DrawnCard(
+                        value = gameState.drawnCard.value.toString(),
+                        label = "Drawn Card",
+                        modifier = Modifier.weight(1f),
+                    )
                 }
             }
 
-            // Bottom spacing
+            // ── Player Grids ──────────────────────────────────────────────
+            if (gameState != null) {
+                gameState.players.forEachIndexed { index, player ->
+                    val isCurrentPlayer = index == gameState.currentPlayerIndex
+                    val board = player.board
+                    val grid = (0 until BoardLayout.ROWS).map { row ->
+                        (0 until BoardLayout.COLUMNS).map { col ->
+                            board.slotAt(BoardPosition(row, col))
+                        }
+                    }
+
+                    Surface(
+                        shape = MaterialTheme.shapes.large,
+                        color = SurfaceWhite,
+                        shadowElevation = if (isCurrentPlayer) 4.dp else 1.dp,
+                        border = if (isCurrentPlayer)
+                            androidx.compose.foundation.BorderStroke(2.dp, PrimaryGreen)
+                        else null,
+                    ) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    text = if (isCurrentPlayer) "${player.id}'s Grid (Your Turn)" else "${player.id}'s Grid",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontWeight = FontWeight.Bold,
+                                    color = if (isCurrentPlayer) PrimaryGreen else MaterialTheme.colorScheme.onSurface,
+                                )
+                                Surface(
+                                    shape = MaterialTheme.shapes.extraLarge,
+                                    color = GreenSurface,
+                                ) {
+                                    Text(
+                                        text = "Score: ${board.rawScore()}",
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = PrimaryGreen,
+                                        fontWeight = FontWeight.Bold,
+                                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                                    )
+                                }
+                            }
+                            Spacer(modifier = Modifier.height(12.dp))
+                            CardGrid(
+                                grid = grid,
+                                onCardTap = if (isCurrentPlayer && pendingAction != null) { row, col ->
+                                    val pos = BoardPosition(row, col)
+                                    val slot = board.slotAt(pos)
+                                    when (pendingAction) {
+                                        PendingAction.PLACE_CARD -> {
+                                            onReplaceDrawnCard(pos)
+                                            pendingAction = null
+                                        }
+                                        PendingAction.DISCARD_AND_REVEAL -> {
+                                            if (slot is BoardSlot.Occupied && !slot.faceUp) {
+                                                onDiscardAndReveal(pos)
+                                                pendingAction = null
+                                            }
+                                        }
+                                        null -> {}
+                                    }
+                                } else null,
+                            )
+                        }
+                    }
+                }
+            }
+
             Spacer(modifier = Modifier.height(8.dp))
         }
 
         // ── Action Buttons ────────────────────────────────────────────────
-        Surface(
-            color = SurfaceWhite,
-            shadowElevation = 8.dp,
-        ) {
+        Surface(color = SurfaceWhite, shadowElevation = 8.dp) {
             Column(
                 modifier = Modifier.padding(horizontal = 20.dp, vertical = 14.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                PrimaryButton(text = "REVEAL CARD", onClick = {})
-                SecondaryButton(text = "Swap with Discard", onClick = {})
-                // Timer chip
-                Surface(
-                    shape = MaterialTheme.shapes.extraLarge,
-                    color = BlueSurface,
-                    modifier = Modifier.align(Alignment.CenterHorizontally),
-                ) {
-                    Text(
-                        text = "⏱  24s remaining",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
-                    )
+                when (gameState?.phase) {
+                    GamePhase.AWAITING_DRAW, GamePhase.FINAL_TURNS -> {
+                        PrimaryButton(text = "DRAW FROM DECK", onClick = onDrawFromDeck)
+                        SecondaryButton(text = "Take from Discard", onClick = onTakeDiscardCard)
+                    }
+                    GamePhase.AWAITING_REPLACEMENT -> {
+                        PrimaryButton(
+                            text = if (pendingAction == PendingAction.PLACE_CARD) "← Tap a card on the grid" else "PLACE DRAWN CARD",
+                            onClick = { pendingAction = PendingAction.PLACE_CARD },
+                        )
+                        SecondaryButton(
+                            text = if (pendingAction == PendingAction.DISCARD_AND_REVEAL) "← Tap a face-down card" else "Discard & Reveal",
+                            onClick = { pendingAction = PendingAction.DISCARD_AND_REVEAL },
+                        )
+                    }
+                    GamePhase.ROUND_FINISHED -> {
+                        PrimaryButton(text = "VIEW RESULTS", onClick = { showResults = true })
+                    }
+                    else -> {
+                        // NOT_STARTED or null: show disabled placeholder
+                        PrimaryButton(text = "DRAW FROM DECK", onClick = {}, enabled = false)
+                    }
                 }
             }
         }
+    }
+
+    // ── Round Results Dialog ──────────────────────────────────────────────
+    if (showResults && gameState?.roundResult != null) {
+        AlertDialog(
+            onDismissRequest = { showResults = false },
+            title = { Text("Round Results", fontWeight = FontWeight.Bold) },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    gameState.roundResult.scores
+                        .sortedBy { it.finalScore }
+                        .forEach { score ->
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                            ) {
+                                val suffix = when {
+                                    score.playerId == gameState.roundResult.finisherPlayerId -> " 🏁"
+                                    score.finalScore != score.rawScore -> " (×2)"
+                                    else -> ""
+                                }
+                                Text(text = "${score.playerId}$suffix", style = MaterialTheme.typography.bodyMedium)
+                                Text(
+                                    text = "${score.finalScore} pts",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    fontWeight = FontWeight.Bold,
+                                    color = PrimaryGreen,
+                                )
+                            }
+                        }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showResults = false; onBack() }) {
+                    Text("Back to Lobby")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showResults = false }) {
+                    Text("Close")
+                }
+            },
+        )
     }
 }
 
 // ── Subcomponents ────────────────────────────────────────────────────────────
 
 @Composable
-private fun PlayerPill(player: GamePlayer, modifier: Modifier = Modifier) {
+private fun PlayerPill(
+    name: String,
+    score: Int,
+    isActive: Boolean,
+    modifier: Modifier = Modifier,
+) {
     Surface(
         shape = MaterialTheme.shapes.extraLarge,
-        color = if (player.isActive) PrimaryGreen else MaterialTheme.colorScheme.surface,
-        border = if (!player.isActive)
-            androidx.compose.foundation.BorderStroke(1.dp, BorderColor)
-        else null,
+        color = if (isActive) PrimaryGreen else MaterialTheme.colorScheme.surface,
+        border = if (!isActive) androidx.compose.foundation.BorderStroke(1.dp, BorderColor) else null,
         modifier = modifier,
     ) {
         Column(
@@ -247,15 +374,16 @@ private fun PlayerPill(player: GamePlayer, modifier: Modifier = Modifier) {
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
-                text = player.name,
+                text = name,
                 style = MaterialTheme.typography.labelSmall,
-                color = if (player.isActive) SurfaceWhite else MutedText,
+                color = if (isActive) SurfaceWhite else MutedText,
                 fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
             )
             Text(
-                text = "${player.score} pts",
+                text = "$score pts",
                 style = MaterialTheme.typography.labelMedium,
-                color = if (player.isActive) MintGreen else MaterialTheme.colorScheme.onSurface,
+                color = if (isActive) MintGreen else MaterialTheme.colorScheme.onSurface,
                 fontWeight = FontWeight.Bold,
             )
         }
@@ -263,94 +391,7 @@ private fun PlayerPill(player: GamePlayer, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun ActionMarketSection() {
-    Surface(
-        shape = MaterialTheme.shapes.large,
-        color = SurfaceWhite,
-        shadowElevation = 2.dp,
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = "ACTION MARKET",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = PrimaryGreen,
-                    fontWeight = FontWeight.Bold,
-                )
-                Surface(
-                    shape = MaterialTheme.shapes.extraLarge,
-                    color = GreenSurface,
-                ) {
-                    Text(
-                        text = "3 cards",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = PrimaryGreen,
-                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
-                    )
-                }
-            }
-            Spacer(modifier = Modifier.height(14.dp))
-
-            // Central action deck
-            Box(
-                modifier = Modifier
-                    .size(72.dp)
-                    .background(
-                        brush = Brush.verticalGradient(
-                            colors = listOf(PrimaryGreen, GreenDark),
-                        ),
-                        shape = RoundedCornerShape(14.dp),
-                    )
-                    .border(
-                        width = 2.dp,
-                        color = MintGreen.copy(alpha = 0.5f),
-                        shape = RoundedCornerShape(14.dp),
-                    ),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = "⚡",
-                    style = MaterialTheme.typography.headlineMedium,
-                )
-            }
-
-            Spacer(modifier = Modifier.height(14.dp))
-
-            // Action card chips
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                actionCards.forEach { action ->
-                    Surface(
-                        shape = MaterialTheme.shapes.large,
-                        color = GreenSurface,
-                        modifier = Modifier.weight(1f),
-                    ) {
-                        Text(
-                            text = action,
-                            style = MaterialTheme.typography.labelMedium,
-                            color = PrimaryGreen,
-                            fontWeight = FontWeight.SemiBold,
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.padding(vertical = 10.dp),
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun DeckCard(label: String, modifier: Modifier = Modifier) {
+private fun DeckCard(size: Int?, label: String, modifier: Modifier = Modifier) {
     Surface(
         shape = MaterialTheme.shapes.large,
         color = SurfaceWhite,
@@ -358,7 +399,7 @@ private fun DeckCard(label: String, modifier: Modifier = Modifier) {
         modifier = modifier,
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(12.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Box(
@@ -366,22 +407,24 @@ private fun DeckCard(label: String, modifier: Modifier = Modifier) {
                     .fillMaxWidth()
                     .aspectRatio(0.75f)
                     .background(
-                        brush = Brush.verticalGradient(
-                            colors = listOf(PrimaryGreen, GreenDark),
-                        ),
+                        brush = Brush.verticalGradient(listOf(PrimaryGreen, GreenDark)),
                         shape = MaterialTheme.shapes.medium,
                     ),
                 contentAlignment = Alignment.Center,
             ) {
-                Text(text = "?", style = MaterialTheme.typography.headlineLarge, color = MintGreen)
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(text = "?", style = MaterialTheme.typography.headlineLarge, color = MintGreen)
+                    if (size != null) {
+                        Text(
+                            text = "$size left",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MintGreen.copy(alpha = 0.8f),
+                        )
+                    }
+                }
             }
             Spacer(modifier = Modifier.height(6.dp))
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelMedium,
-                color = MutedText,
-                textAlign = TextAlign.Center,
-            )
+            Text(text = label, style = MaterialTheme.typography.labelMedium, color = MutedText, textAlign = TextAlign.Center)
         }
     }
 }
@@ -395,22 +438,60 @@ private fun DiscardCard(value: String, label: String, modifier: Modifier = Modif
         modifier = modifier,
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(12.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            val numValue = value.toIntOrNull()
+            val bgColor = when {
+                numValue == null -> CardHiddenBg
+                numValue <= 0 -> CardNegativeBg
+                else -> CardPositiveBg
+            }
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .aspectRatio(0.75f)
-                    .background(
-                        color = CardPositiveBg,
-                        shape = MaterialTheme.shapes.medium,
-                    )
-                    .border(
-                        width = 1.dp,
-                        color = BorderColor,
-                        shape = MaterialTheme.shapes.medium,
-                    ),
+                    .background(color = bgColor, shape = MaterialTheme.shapes.medium)
+                    .border(width = 1.dp, color = BorderColor, shape = MaterialTheme.shapes.medium),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontWeight = FontWeight.ExtraBold,
+                )
+            }
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(text = label, style = MaterialTheme.typography.labelMedium, color = MutedText, textAlign = TextAlign.Center)
+        }
+    }
+}
+
+@Composable
+private fun DrawnCard(value: String, label: String, modifier: Modifier = Modifier) {
+    Surface(
+        shape = MaterialTheme.shapes.large,
+        color = SurfaceWhite,
+        shadowElevation = 4.dp,
+        border = androidx.compose.foundation.BorderStroke(2.dp, PrimaryGreen),
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            val numValue = value.toIntOrNull()
+            val bgColor = when {
+                numValue == null -> CardHiddenBg
+                numValue <= 0 -> CardNegativeBg
+                else -> CardPositiveBg
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(0.75f)
+                    .background(color = bgColor, shape = MaterialTheme.shapes.medium),
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
@@ -424,7 +505,8 @@ private fun DiscardCard(value: String, label: String, modifier: Modifier = Modif
             Text(
                 text = label,
                 style = MaterialTheme.typography.labelMedium,
-                color = MutedText,
+                color = PrimaryGreen,
+                fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center,
             )
         }
@@ -432,18 +514,25 @@ private fun DiscardCard(value: String, label: String, modifier: Modifier = Modif
 }
 
 @Composable
-private fun CardGrid(cards: List<List<String?>>) {
+private fun CardGrid(
+    grid: List<List<BoardSlot>>,
+    onCardTap: ((row: Int, col: Int) -> Unit)?,
+) {
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        cards.forEach { row ->
+        grid.forEachIndexed { rowIndex, row ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                row.forEach { value ->
-                    GameCardTile(value = value, modifier = Modifier.weight(1f))
+                row.forEachIndexed { colIndex, slot ->
+                    GameCardTile(
+                        slot = slot,
+                        onClick = onCardTap?.let { { it(rowIndex, colIndex) } },
+                        modifier = Modifier.weight(1f),
+                    )
                 }
             }
         }
@@ -451,32 +540,39 @@ private fun CardGrid(cards: List<List<String?>>) {
 }
 
 @Composable
-private fun GameCardTile(value: String?, modifier: Modifier = Modifier) {
-    val isHidden = value == null
-    val numValue = value?.toIntOrNull()
-    val bgColor = when {
-        isHidden -> CardHiddenBg
-        numValue != null && numValue <= 0 -> CardNegativeBg
-        else -> CardPositiveBg
+private fun GameCardTile(
+    slot: BoardSlot,
+    onClick: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    val (bgColor, textColor, label) = when (slot) {
+        is BoardSlot.Cleared -> Triple(GreenSurface, MutedText, "✓")
+        is BoardSlot.Occupied -> if (!slot.faceUp) {
+            Triple(CardHiddenBg, CardHiddenText, "?")
+        } else {
+            val numVal = slot.card.value
+            val bg = if (numVal <= 0) CardNegativeBg else CardPositiveBg
+            Triple(bg, MaterialTheme.colorScheme.onBackground, numVal.toString())
+        }
     }
-    val textColor = when {
-        isHidden -> CardHiddenText
-        else -> MaterialTheme.colorScheme.onBackground
-    }
+
+    val tappable = onClick != null && slot is BoardSlot.Occupied && slot != BoardSlot.Cleared
 
     Box(
         modifier = modifier
             .aspectRatio(0.65f)
+            .clip(RoundedCornerShape(10.dp))
             .background(color = bgColor, shape = RoundedCornerShape(10.dp))
             .border(
-                width = 1.dp,
-                color = if (isHidden) MintGreen.copy(alpha = 0.4f) else BorderColor,
+                width = if (tappable) 2.dp else 1.dp,
+                color = if (tappable) PrimaryGreen else if (slot is BoardSlot.Occupied && !slot.faceUp) MintGreen.copy(alpha = 0.4f) else BorderColor,
                 shape = RoundedCornerShape(10.dp),
-            ),
+            )
+            .then(if (onClick != null && slot !is BoardSlot.Cleared) Modifier.clickable { onClick() } else Modifier),
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            text = value ?: "?",
+            text = label,
             style = MaterialTheme.typography.titleLarge,
             color = textColor,
             fontWeight = FontWeight.ExtraBold,
@@ -489,6 +585,6 @@ private fun GameCardTile(value: String?, modifier: Modifier = Modifier) {
 @Composable
 private fun GameScreenPreview() {
     SkyjoTheme {
-        GameScreen(onBack = {})
+        GameScreen(gameState = null, onBack = {})
     }
 }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/lobby/LobbyScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/lobby/LobbyScreen.kt
@@ -15,15 +15,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.PersonAdd
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -34,14 +36,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import at.aau.se2.skyjo.ui.components.AvatarBadge
 import at.aau.se2.skyjo.ui.components.PrimaryButton
 import at.aau.se2.skyjo.ui.components.SkyjoCard
+import at.aau.se2.skyjo.ui.game.GameViewModel
 import at.aau.se2.skyjo.ui.theme.BackgroundGray
 import at.aau.se2.skyjo.ui.theme.BorderColor
 import at.aau.se2.skyjo.ui.theme.GreenSurface
@@ -51,21 +53,18 @@ import at.aau.se2.skyjo.ui.theme.PrimaryGreen
 import at.aau.se2.skyjo.ui.theme.SkyjoTheme
 import at.aau.se2.skyjo.ui.theme.SurfaceWhite
 
-private data class DummyPlayer(val name: String, val isHost: Boolean = false)
-
-private val dummyPlayers = listOf(
-    DummyPlayer("Alice", isHost = true),
-    DummyPlayer("Bob"),
-)
+private const val MAX_PLAYERS = 8
 
 @Composable
 fun LobbyScreen(
+    gameViewModel: GameViewModel,
     onStartGame: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var playerNames by remember { mutableStateOf(listOf("Player 1", "Player 2")) }
     var selectedRounds by remember { mutableIntStateOf(5) }
-    var selectedMode by remember { mutableStateOf("Action") }
+    var selectedMode by remember { mutableStateOf("Classic") }
 
     Column(
         modifier = modifier
@@ -92,7 +91,7 @@ fun LobbyScreen(
                     )
                 }
                 Text(
-                    text = "SKYJO ACTION",
+                    text = "SKYJO",
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.ExtraBold,
                     color = PrimaryGreen,
@@ -116,7 +115,7 @@ fun LobbyScreen(
                     fontWeight = FontWeight.Bold,
                 )
                 Text(
-                    text = "Waiting for\nPlayers",
+                    text = "Who's playing?",
                     style = MaterialTheme.typography.headlineLarge,
                     color = MaterialTheme.colorScheme.onBackground,
                 )
@@ -135,27 +134,24 @@ fun LobbyScreen(
                             style = MaterialTheme.typography.titleMedium,
                         )
                         Text(
-                            text = "${dummyPlayers.size} / 4",
+                            text = "${playerNames.size} / $MAX_PLAYERS",
                             style = MaterialTheme.typography.titleMedium,
                             color = PrimaryGreen,
                             fontWeight = FontWeight.ExtraBold,
                         )
                     }
                     Spacer(modifier = Modifier.height(10.dp))
-                    // Progress bar
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(8.dp)
-                            .clip(MaterialTheme.shapes.extraLarge)
-                            .background(GreenSurface),
+                            .background(GreenSurface, MaterialTheme.shapes.extraLarge),
                     ) {
                         Box(
                             modifier = Modifier
-                                .fillMaxWidth(fraction = dummyPlayers.size / 4f)
+                                .fillMaxWidth(fraction = playerNames.size / MAX_PLAYERS.toFloat())
                                 .height(8.dp)
-                                .clip(MaterialTheme.shapes.extraLarge)
-                                .background(PrimaryGreen),
+                                .background(PrimaryGreen, MaterialTheme.shapes.extraLarge),
                         )
                     }
                 }
@@ -163,19 +159,23 @@ fun LobbyScreen(
 
             // ── Player Slots ─────────────────────────────────────────────
             Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                dummyPlayers.forEach { player ->
-                    FilledPlayerSlot(player = player)
+                playerNames.forEachIndexed { index, name ->
+                    EditablePlayerSlot(
+                        name = name,
+                        isHost = index == 0,
+                        onNameChange = { newName ->
+                            playerNames = playerNames.toMutableList().also { it[index] = newName }
+                        },
+                        onRemove = if (playerNames.size > 2) {
+                            { playerNames = playerNames.toMutableList().also { it.removeAt(index) } }
+                        } else null,
+                    )
                 }
-                // Empty invite slot
-                EmptyPlayerSlot(
-                    icon = Icons.Default.PersonAdd,
-                    label = "Invite Friend",
-                )
-                // Open to public slot
-                EmptyPlayerSlot(
-                    icon = Icons.Default.Search,
-                    label = "Open to Public",
-                )
+                if (playerNames.size < MAX_PLAYERS) {
+                    AddPlayerSlot(
+                        onClick = { playerNames = playerNames + "Player ${playerNames.size + 1}" },
+                    )
+                }
             }
 
             // ── Match Rules ──────────────────────────────────────────────
@@ -240,10 +240,17 @@ fun LobbyScreen(
             Column(
                 modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp),
             ) {
-                PrimaryButton(text = "START GAME", onClick = onStartGame)
+                PrimaryButton(
+                    text = "START GAME",
+                    onClick = {
+                        val names = playerNames.map { it.trim().ifBlank { "Player" } }
+                        gameViewModel.startGame(names)
+                        onStartGame()
+                    },
+                )
                 Spacer(modifier = Modifier.height(6.dp))
                 Text(
-                    text = "All players must be ready to start",
+                    text = "Each player reveals 2 cards at the start",
                     style = MaterialTheme.typography.bodySmall,
                     color = MutedText,
                     modifier = Modifier.fillMaxWidth(),
@@ -255,83 +262,89 @@ fun LobbyScreen(
 }
 
 @Composable
-private fun FilledPlayerSlot(player: DummyPlayer) {
+private fun EditablePlayerSlot(
+    name: String,
+    isHost: Boolean,
+    onNameChange: (String) -> Unit,
+    onRemove: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
     Surface(
         shape = MaterialTheme.shapes.large,
         color = SurfaceWhite,
         shadowElevation = 2.dp,
+        modifier = modifier,
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
+                .padding(horizontal = 12.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             AvatarBadge(
-                initial = player.name.first(),
-                size = 44,
+                initial = name.firstOrNull()?.uppercaseChar() ?: 'P',
+                size = 40,
                 showOnlineIndicator = true,
                 backgroundColor = MintGreen,
                 textColor = PrimaryGreen,
             )
-            Spacer(modifier = Modifier.width(14.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = if (player.isHost) "${player.name}  👑" else player.name,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Text(
-                    text = if (player.isHost) "Host" else "Player",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MutedText,
-                )
-            }
-            Surface(
-                shape = MaterialTheme.shapes.extraLarge,
-                color = MintGreen,
-            ) {
-                Text(
-                    text = "Ready",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = PrimaryGreen,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 5.dp),
-                )
+            Spacer(modifier = Modifier.width(12.dp))
+            OutlinedTextField(
+                value = name,
+                onValueChange = onNameChange,
+                modifier = Modifier.weight(1f),
+                singleLine = true,
+                label = { Text(if (isHost) "Host" else "Player") },
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                shape = MaterialTheme.shapes.medium,
+            )
+            if (onRemove != null) {
+                Spacer(modifier = Modifier.width(4.dp))
+                IconButton(onClick = onRemove, modifier = Modifier.size(36.dp)) {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = "Remove player",
+                        tint = MutedText,
+                    )
+                }
             }
         }
     }
 }
 
 @Composable
-private fun EmptyPlayerSlot(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
-    label: String,
-) {
+private fun AddPlayerSlot(onClick: () -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(72.dp)
-            .border(
-                width = 1.5.dp,
-                color = BorderColor,
-                shape = RoundedCornerShape(20.dp),
-            ),
+            .height(64.dp)
+            .border(width = 1.5.dp, color = BorderColor, shape = RoundedCornerShape(20.dp)),
         contentAlignment = Alignment.Center,
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                imageVector = icon,
-                contentDescription = label,
-                tint = MutedText,
-                modifier = Modifier.size(20.dp),
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = label,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MutedText,
-            )
+        Surface(
+            onClick = onClick,
+            color = androidx.compose.ui.graphics.Color.Transparent,
+            modifier = Modifier.fillMaxSize(),
+            shape = RoundedCornerShape(20.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxSize(),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.PersonAdd,
+                    contentDescription = "Add player",
+                    tint = MutedText,
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "Add Player",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MutedText,
+                )
+            }
         }
     }
 }
@@ -347,9 +360,7 @@ private fun ToggleChip(
         onClick = onClick,
         shape = MaterialTheme.shapes.large,
         color = if (selected) PrimaryGreen else MaterialTheme.colorScheme.surface,
-        border = if (!selected)
-            androidx.compose.foundation.BorderStroke(1.dp, BorderColor)
-        else null,
+        border = if (!selected) androidx.compose.foundation.BorderStroke(1.dp, BorderColor) else null,
         modifier = modifier,
     ) {
         Text(
@@ -369,6 +380,6 @@ private fun ToggleChip(
 @Composable
 private fun LobbyScreenPreview() {
     SkyjoTheme {
-        LobbyScreen(onStartGame = {}, onBack = {})
+        LobbyScreen(gameViewModel = GameViewModel(), onStartGame = {}, onBack = {})
     }
 }

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
@@ -3,7 +3,6 @@ package at.aau.se2.skyjo.ui.screens.game
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import at.aau.se2.skyjo.ui.theme.SkyjoTheme
 import org.junit.Rule
@@ -22,30 +21,20 @@ class GameScreenTest {
     fun gameScreen_renders_without_crash() {
         composeTestRule.setContent {
             SkyjoTheme {
-                GameScreen(onBack = {})
+                GameScreen(gameState = null, onBack = {})
             }
         }
         composeTestRule.onNodeWithText("SKYJO ACTION").assertIsDisplayed()
     }
 
     @Test
-    fun gameScreen_shows_reveal_card_button() {
+    fun gameScreen_shows_draw_button_when_no_game() {
         composeTestRule.setContent {
             SkyjoTheme {
-                GameScreen(onBack = {})
+                GameScreen(gameState = null, onBack = {})
             }
         }
-        composeTestRule.onNodeWithText("REVEAL CARD").assertIsDisplayed()
-    }
-
-    @Test
-    fun gameScreen_shows_action_market() {
-        composeTestRule.setContent {
-            SkyjoTheme {
-                GameScreen(onBack = {})
-            }
-        }
-        composeTestRule.onNodeWithText("ACTION MARKET").assertIsDisplayed()
+        composeTestRule.onNodeWithText("DRAW FROM DECK").assertIsDisplayed()
     }
 
     @Test
@@ -53,7 +42,7 @@ class GameScreenTest {
         var backPressed = false
         composeTestRule.setContent {
             SkyjoTheme {
-                GameScreen(onBack = { backPressed = true })
+                GameScreen(gameState = null, onBack = { backPressed = true })
             }
         }
         composeTestRule.waitForIdle()

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/lobby/LobbyScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/lobby/LobbyScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import at.aau.se2.skyjo.ui.game.GameViewModel
 import at.aau.se2.skyjo.ui.theme.SkyjoTheme
 import org.junit.Rule
 import org.junit.Test
@@ -23,6 +24,7 @@ class LobbyScreenTest {
         composeTestRule.setContent {
             SkyjoTheme {
                 LobbyScreen(
+                    gameViewModel = GameViewModel(),
                     onStartGame = {},
                     onBack = {},
                 )
@@ -36,6 +38,7 @@ class LobbyScreenTest {
         composeTestRule.setContent {
             SkyjoTheme {
                 LobbyScreen(
+                    gameViewModel = GameViewModel(),
                     onStartGame = {},
                     onBack = {},
                 )
@@ -50,6 +53,7 @@ class LobbyScreenTest {
         composeTestRule.setContent {
             SkyjoTheme {
                 LobbyScreen(
+                    gameViewModel = GameViewModel(),
                     onStartGame = { started = true },
                     onBack = {},
                 )
@@ -65,6 +69,7 @@ class LobbyScreenTest {
         composeTestRule.setContent {
             SkyjoTheme {
                 LobbyScreen(
+                    gameViewModel = GameViewModel(),
                     onStartGame = {},
                     onBack = { backPressed = true },
                 )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application") version "8.7.3" apply false
     id("org.jetbrains.kotlin.android") version "2.2.10" apply false
+    id("org.jetbrains.kotlin.jvm") version "2.2.10" apply false
     id("org.sonarqube") version "5.0.0.4638"
     id("org.jetbrains.kotlin.plugin.compose") version "2.2.10" apply false
 }

--- a/game/build.gradle.kts
+++ b/game/build.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+    kotlin("jvm") version "2.2.10"
+    id("jacoco")
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+    testImplementation("org.assertj:assertj-core:3.26.0")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        xml.outputLocation.set(
+            file("${project.projectDir}/build/reports/jacoco/test/jacocoTestReport.xml")
+        )
+    }
+}
+
+sonar {
+    properties {
+        property("sonar.sources", "src/main/kotlin")
+        property("sonar.tests", "src/test/kotlin")
+        property(
+            "sonar.coverage.jacoco.xmlReportPaths",
+            "${project.projectDir}/build/reports/jacoco/test/jacocoTestReport.xml"
+        )
+        property("sonar.kotlin.file.suffixes", ".kt,.kts")
+        property("sonar.sourceEncoding", "UTF-8")
+    }
+}

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/error/SkyjoGameException.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/error/SkyjoGameException.kt
@@ -1,0 +1,11 @@
+package at.aau.se2.skyjo.game.error
+
+open class SkyjoGameException(message: String) : RuntimeException(message)
+
+class InvalidGameSetupException(message: String) : SkyjoGameException(message)
+
+class InvalidMoveException(message: String) : SkyjoGameException(message)
+
+class GameNotStartedException(message: String) : SkyjoGameException(message)
+
+class RoundAlreadyFinishedException(message: String) : SkyjoGameException(message)

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/model/BoardLayout.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/model/BoardLayout.kt
@@ -1,0 +1,24 @@
+package at.aau.se2.skyjo.game.model
+
+object BoardLayout {
+    const val ROWS: Int = 3
+    const val COLUMNS: Int = 4
+
+    val POSITIONS: List<BoardPosition> = buildList {
+        for (row in 0 until ROWS) {
+            for (column in 0 until COLUMNS) {
+                add(BoardPosition(row, column))
+            }
+        }
+    }
+
+    val VERTICAL_LINES: List<List<BoardPosition>> =
+        (0 until COLUMNS).map { column ->
+            (0 until ROWS).map { row -> BoardPosition(row, column) }
+        }
+
+    val HORIZONTAL_LINES: List<List<BoardPosition>> =
+        (0 until ROWS).map { row ->
+            (0 until COLUMNS).map { column -> BoardPosition(row, column) }
+        }
+}

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/model/BoardPosition.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/model/BoardPosition.kt
@@ -1,0 +1,11 @@
+package at.aau.se2.skyjo.game.model
+
+data class BoardPosition(
+    val row: Int,
+    val column: Int,
+) {
+    init {
+        require(row in 0 until BoardLayout.ROWS) { "row must be between 0 and ${BoardLayout.ROWS - 1}" }
+        require(column in 0 until BoardLayout.COLUMNS) { "column must be between 0 and ${BoardLayout.COLUMNS - 1}" }
+    }
+}

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/model/BoardSlot.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/model/BoardSlot.kt
@@ -1,0 +1,10 @@
+package at.aau.se2.skyjo.game.model
+
+sealed interface BoardSlot {
+    data class Occupied(
+        val card: SkyjoCard,
+        val faceUp: Boolean,
+    ) : BoardSlot
+
+    data object Cleared : BoardSlot
+}

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/model/DiscardPile.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/model/DiscardPile.kt
@@ -1,0 +1,34 @@
+package at.aau.se2.skyjo.game.model
+
+data class DiscardPile(
+    val cards: List<SkyjoCard>,
+) {
+    val size: Int
+        get() = cards.size
+
+    fun topCard(): SkyjoCard {
+        require(cards.isNotEmpty()) { "discard pile is empty" }
+        return cards.last()
+    }
+
+    fun takeTop(): DiscardDrawResult {
+        require(cards.isNotEmpty()) { "discard pile is empty" }
+        return DiscardDrawResult(
+            card = cards.last(),
+            remainingPile = copy(cards = cards.dropLast(1)),
+        )
+    }
+
+    fun add(card: SkyjoCard): DiscardPile = copy(cards = cards + card)
+
+    fun addAll(newCards: List<SkyjoCard>): DiscardPile = copy(cards = cards + newCards)
+
+    companion object {
+        fun empty(): DiscardPile = DiscardPile(emptyList())
+    }
+}
+
+data class DiscardDrawResult(
+    val card: SkyjoCard,
+    val remainingPile: DiscardPile,
+)

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/model/DrawPile.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/model/DrawPile.kt
@@ -1,0 +1,25 @@
+package at.aau.se2.skyjo.game.model
+
+data class DrawPile(
+    val cards: List<SkyjoCard>,
+) {
+    val size: Int
+        get() = cards.size
+
+    fun draw(): DrawResult {
+        require(cards.isNotEmpty()) { "draw pile is empty" }
+        return DrawResult(
+            card = cards.last(),
+            remainingPile = copy(cards = cards.dropLast(1)),
+        )
+    }
+
+    companion object {
+        fun empty(): DrawPile = DrawPile(emptyList())
+    }
+}
+
+data class DrawResult(
+    val card: SkyjoCard,
+    val remainingPile: DrawPile,
+)

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/model/DrawSource.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/model/DrawSource.kt
@@ -1,0 +1,6 @@
+package at.aau.se2.skyjo.game.model
+
+enum class DrawSource {
+    DECK,
+    DISCARD,
+}

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/model/GamePhase.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/model/GamePhase.kt
@@ -1,0 +1,9 @@
+package at.aau.se2.skyjo.game.model
+
+enum class GamePhase {
+    NOT_STARTED,
+    AWAITING_DRAW,
+    AWAITING_REPLACEMENT,
+    FINAL_TURNS,
+    ROUND_FINISHED,
+}

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/model/GameState.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/model/GameState.kt
@@ -1,0 +1,21 @@
+package at.aau.se2.skyjo.game.model
+
+data class GameState(
+    val players: List<PlayerState> = emptyList(),
+    val currentPlayerIndex: Int = 0,
+    val drawPile: DrawPile = DrawPile.empty(),
+    val discardPile: DiscardPile = DiscardPile.empty(),
+    val phase: GamePhase = GamePhase.NOT_STARTED,
+    val drawnCard: SkyjoCard? = null,
+    val drawSource: DrawSource? = null,
+    val finisherPlayerId: String? = null,
+    val finalTurnsRemaining: Int = 0,
+    val roundResult: RoundResult? = null,
+    val shuffleSeed: Long? = null,
+    val shuffleCount: Int = 0,
+) {
+    val currentPlayerId: String?
+        get() = players.getOrNull(currentPlayerIndex)?.id
+
+    fun currentPlayer(): PlayerState = players[currentPlayerIndex]
+}

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/model/PlayerBoard.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/model/PlayerBoard.kt
@@ -1,0 +1,127 @@
+package at.aau.se2.skyjo.game.model
+
+data class PlayerBoard(
+    val slots: Map<BoardPosition, BoardSlot>,
+) {
+    init {
+        require(slots.keys == BoardLayout.POSITIONS.toSet()) { "board must define all positions exactly once" }
+    }
+
+    fun slotAt(position: BoardPosition): BoardSlot = slots.getValue(position)
+
+    fun hiddenPositions(): List<BoardPosition> =
+        BoardLayout.POSITIONS.filter { position ->
+            val slot = slotAt(position)
+            slot is BoardSlot.Occupied && !slot.faceUp
+        }
+
+    fun hasHiddenCards(): Boolean = hiddenPositions().isNotEmpty()
+
+    fun reveal(position: BoardPosition): PlayerBoard {
+        val slot = slotAt(position)
+        require(slot is BoardSlot.Occupied) { "cannot reveal a cleared slot" }
+        require(!slot.faceUp) { "card at $position is already face up" }
+
+        return copy(
+            slots = slots + (position to slot.copy(faceUp = true)),
+        )
+    }
+
+    fun replace(position: BoardPosition, card: SkyjoCard): ReplacementResult {
+        val slot = slotAt(position)
+        require(slot is BoardSlot.Occupied) { "cannot replace a cleared slot" }
+
+        val updatedBoard = copy(
+            slots = slots + (position to BoardSlot.Occupied(card = card, faceUp = true)),
+        )
+        return ReplacementResult(
+            board = updatedBoard,
+            replacedCard = slot.card,
+        )
+    }
+
+    fun fullyReveal(): PlayerBoard {
+        val updatedSlots = BoardLayout.POSITIONS.associateWith { position ->
+            when (val slot = slotAt(position)) {
+                is BoardSlot.Cleared -> slot
+                is BoardSlot.Occupied -> slot.copy(faceUp = true)
+            }
+        }
+        return copy(slots = updatedSlots)
+    }
+
+    fun clearCompletedLines(): BoardCleanupResult {
+        val matchedPositions = (BoardLayout.VERTICAL_LINES + BoardLayout.HORIZONTAL_LINES)
+            .filter(::isCompletedMatchingLine)
+            .flatten()
+            .distinct()
+
+        if (matchedPositions.isEmpty()) {
+            return BoardCleanupResult(board = this, removedCards = emptyList())
+        }
+
+        val removedCards = matchedPositions
+            .sortedWith(compareBy(BoardPosition::row, BoardPosition::column))
+            .map { position -> (slotAt(position) as BoardSlot.Occupied).card }
+
+        val updatedSlots = slots.toMutableMap()
+        matchedPositions.forEach { position ->
+            updatedSlots[position] = BoardSlot.Cleared
+        }
+
+        return BoardCleanupResult(
+            board = copy(slots = updatedSlots),
+            removedCards = removedCards,
+        )
+    }
+
+    fun rawScore(): Int =
+        BoardLayout.POSITIONS.sumOf { position ->
+            when (val slot = slotAt(position)) {
+                is BoardSlot.Cleared -> 0
+                is BoardSlot.Occupied -> slot.card.value
+            }
+        }
+
+    fun visibleValueSum(positions: Set<BoardPosition>): Int =
+        positions.sumOf { position ->
+            val slot = slotAt(position)
+            require(slot is BoardSlot.Occupied && slot.faceUp) { "position $position must contain a face-up card" }
+            slot.card.value
+        }
+
+    private fun isCompletedMatchingLine(line: List<BoardPosition>): Boolean {
+        val occupiedSlots = line.map { position -> slotAt(position) as? BoardSlot.Occupied ?: return false }
+        if (occupiedSlots.any { !it.faceUp }) {
+            return false
+        }
+
+        return occupiedSlots.map { it.card.value }.distinct().size == 1
+    }
+
+    companion object {
+        fun fromCards(cards: List<SkyjoCard>, revealedPositions: Set<BoardPosition>): PlayerBoard {
+            require(cards.size == BoardLayout.POSITIONS.size) { "a player board requires exactly ${BoardLayout.POSITIONS.size} cards" }
+            require(revealedPositions.size == 2) { "exactly two initial reveal positions are required" }
+
+            val slots = BoardLayout.POSITIONS.mapIndexed { index, position ->
+                position to BoardSlot.Occupied(
+                    card = cards[index],
+                    faceUp = position in revealedPositions,
+                )
+            }.toMap()
+
+            return PlayerBoard(slots)
+        }
+    }
+}
+
+data class ReplacementResult(
+    val board: PlayerBoard,
+    val replacedCard: SkyjoCard,
+)
+
+data class BoardCleanupResult(
+    val board: PlayerBoard,
+    val removedCards: List<SkyjoCard>,
+)

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/model/PlayerState.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/model/PlayerState.kt
@@ -1,0 +1,6 @@
+package at.aau.se2.skyjo.game.model
+
+data class PlayerState(
+    val id: String,
+    val board: PlayerBoard,
+)

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/model/RoundResult.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/model/RoundResult.kt
@@ -1,0 +1,12 @@
+package at.aau.se2.skyjo.game.model
+
+data class RoundResult(
+    val finisherPlayerId: String,
+    val scores: List<PlayerRoundScore>,
+) {
+    data class PlayerRoundScore(
+        val playerId: String,
+        val rawScore: Int,
+        val finalScore: Int,
+    )
+}

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/model/SkyjoCard.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/model/SkyjoCard.kt
@@ -1,0 +1,6 @@
+package at.aau.se2.skyjo.game.model
+
+data class SkyjoCard(
+    val id: Int,
+    val value: Int,
+)

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/model/SkyjoDeckFactory.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/model/SkyjoDeckFactory.kt
@@ -1,0 +1,23 @@
+package at.aau.se2.skyjo.game.model
+
+import kotlin.random.Random
+
+object SkyjoDeckFactory {
+    private val cardDistribution: List<Int> = buildList {
+        addAll(List(5) { -2 })
+        addAll(List(10) { -1 })
+        addAll(List(15) { 0 })
+        for (value in 1..12) {
+            addAll(List(10) { value })
+        }
+    }
+
+    fun createShuffledDrawPile(seed: Long? = null): DrawPile {
+        val random = seed?.let(::Random) ?: Random.Default
+        val cards = cardDistribution
+            .mapIndexed { index, value -> SkyjoCard(id = index + 1, value = value) }
+            .shuffled(random)
+
+        return DrawPile(cards)
+    }
+}

--- a/game/src/main/kotlin/at/aau/se2/skyjo/game/service/SkyjoEngine.kt
+++ b/game/src/main/kotlin/at/aau/se2/skyjo/game/service/SkyjoEngine.kt
@@ -1,0 +1,309 @@
+package at.aau.se2.skyjo.game.service
+
+import at.aau.se2.skyjo.game.error.GameNotStartedException
+import at.aau.se2.skyjo.game.error.InvalidGameSetupException
+import at.aau.se2.skyjo.game.error.InvalidMoveException
+import at.aau.se2.skyjo.game.error.RoundAlreadyFinishedException
+import at.aau.se2.skyjo.game.model.BoardLayout
+import at.aau.se2.skyjo.game.model.BoardPosition
+import at.aau.se2.skyjo.game.model.BoardSlot
+import at.aau.se2.skyjo.game.model.DiscardPile
+import at.aau.se2.skyjo.game.model.DrawPile
+import at.aau.se2.skyjo.game.model.DrawSource
+import at.aau.se2.skyjo.game.model.GamePhase
+import at.aau.se2.skyjo.game.model.GameState
+import at.aau.se2.skyjo.game.model.PlayerBoard
+import at.aau.se2.skyjo.game.model.PlayerState
+import at.aau.se2.skyjo.game.model.RoundResult
+import at.aau.se2.skyjo.game.model.SkyjoDeckFactory
+import kotlin.random.Random
+
+class SkyjoEngine {
+
+    fun startGame(
+        playerIds: List<String>,
+        initialReveals: Map<String, Set<BoardPosition>>,
+        seed: Long? = null,
+    ): GameState {
+        validateSetup(playerIds, initialReveals)
+
+        var drawPile = SkyjoDeckFactory.createShuffledDrawPile(seed)
+        val players = playerIds.map { playerId ->
+            val cards = buildList {
+                repeat(BoardLayout.POSITIONS.size) {
+                    val drawResult = drawPile.draw()
+                    add(drawResult.card)
+                    drawPile = drawResult.remainingPile
+                }
+            }
+
+            PlayerState(
+                id = playerId,
+                board = PlayerBoard.fromCards(
+                    cards = cards,
+                    revealedPositions = initialReveals.getValue(playerId),
+                ),
+            )
+        }
+
+        val openingDiscard = drawPile.draw()
+        val startingPlayerIndex = determineStartingPlayerIndex(players, initialReveals)
+
+        return GameState(
+            players = players,
+            currentPlayerIndex = startingPlayerIndex,
+            drawPile = openingDiscard.remainingPile,
+            discardPile = DiscardPile(listOf(openingDiscard.card)),
+            phase = GamePhase.AWAITING_DRAW,
+            shuffleSeed = seed,
+        )
+    }
+
+    fun drawFromDeck(state: GameState): GameState {
+        val playableState = requireActiveRound(state)
+        if (playableState.phase != GamePhase.AWAITING_DRAW && playableState.phase != GamePhase.FINAL_TURNS) {
+            throw InvalidMoveException("cannot draw from deck while phase is ${playableState.phase}")
+        }
+
+        val replenishedState = replenishDrawPileIfNeeded(playableState)
+        val drawResult = replenishedState.drawPile.draw()
+        return replenishedState.copy(
+            drawPile = drawResult.remainingPile,
+            drawnCard = drawResult.card,
+            drawSource = DrawSource.DECK,
+            phase = GamePhase.AWAITING_REPLACEMENT,
+        )
+    }
+
+    fun takeDiscardCard(state: GameState): GameState {
+        val playableState = requireActiveRound(state)
+        if (playableState.phase != GamePhase.AWAITING_DRAW && playableState.phase != GamePhase.FINAL_TURNS) {
+            throw InvalidMoveException("cannot take discard card while phase is ${playableState.phase}")
+        }
+
+        val drawResult = playableState.discardPile.takeTop()
+        return playableState.copy(
+            discardPile = drawResult.remainingPile,
+            drawnCard = drawResult.card,
+            drawSource = DrawSource.DISCARD,
+            phase = GamePhase.AWAITING_REPLACEMENT,
+        )
+    }
+
+    fun replaceDrawnCard(state: GameState, position: BoardPosition): GameState {
+        val playableState = requireAwaitingReplacement(state)
+        val currentPlayer = playableState.currentPlayer()
+        val drawnCard = playableState.drawnCard ?: throw InvalidMoveException("no drawn card is available")
+        val replacementResult = currentPlayer.board.replace(position, drawnCard)
+        val cleanupResult = replacementResult.board.clearCompletedLines()
+
+        val updatedDiscardPile = playableState.discardPile
+            .add(replacementResult.replacedCard)
+            .addAll(cleanupResult.removedCards)
+
+        val updatedPlayers = playableState.players.updated(
+            playableState.currentPlayerIndex,
+            currentPlayer.copy(board = cleanupResult.board),
+        )
+
+        return advanceAfterTurn(
+            state = playableState.copy(
+                players = updatedPlayers,
+                discardPile = updatedDiscardPile,
+                drawnCard = null,
+                drawSource = null,
+            ),
+        )
+    }
+
+    fun discardDrawnCardAndReveal(state: GameState, position: BoardPosition): GameState {
+        val playableState = requireAwaitingReplacement(state)
+        if (playableState.drawSource != DrawSource.DECK) {
+            throw InvalidMoveException("discard and reveal is only allowed after drawing from the deck")
+        }
+
+        val currentPlayer = playableState.currentPlayer()
+        val slot = currentPlayer.board.slotAt(position)
+        if (slot !is BoardSlot.Occupied || slot.faceUp) {
+            throw InvalidMoveException("discard and reveal requires a face-down occupied slot")
+        }
+
+        val revealedBoard = currentPlayer.board.reveal(position)
+        val cleanupResult = revealedBoard.clearCompletedLines()
+        val drawnCard = playableState.drawnCard ?: throw InvalidMoveException("no drawn card is available")
+
+        val updatedPlayers = playableState.players.updated(
+            playableState.currentPlayerIndex,
+            currentPlayer.copy(board = cleanupResult.board),
+        )
+        val updatedDiscardPile = playableState.discardPile
+            .add(drawnCard)
+            .addAll(cleanupResult.removedCards)
+
+        return advanceAfterTurn(
+            state = playableState.copy(
+                players = updatedPlayers,
+                discardPile = updatedDiscardPile,
+                drawnCard = null,
+                drawSource = null,
+            ),
+        )
+    }
+
+    private fun validateSetup(
+        playerIds: List<String>,
+        initialReveals: Map<String, Set<BoardPosition>>,
+    ) {
+        if (playerIds.size !in 2..8) {
+            throw InvalidGameSetupException("Skyjo requires between 2 and 8 players")
+        }
+        if (playerIds.distinct().size != playerIds.size) {
+            throw InvalidGameSetupException("player ids must be unique")
+        }
+        if (playerIds.any { it.isBlank() }) {
+            throw InvalidGameSetupException("player ids must not be blank")
+        }
+        if (initialReveals.keys != playerIds.toSet()) {
+            throw InvalidGameSetupException("initial reveals must be provided for every player id")
+        }
+        if (initialReveals.values.any { it.size != 2 }) {
+            throw InvalidGameSetupException("each player must reveal exactly two positions")
+        }
+    }
+
+    private fun requireActiveRound(state: GameState): GameState {
+        when (state.phase) {
+            GamePhase.NOT_STARTED -> throw GameNotStartedException("game has not been started yet")
+            GamePhase.ROUND_FINISHED -> throw RoundAlreadyFinishedException("round has already finished")
+            else -> return state
+        }
+    }
+
+    private fun requireAwaitingReplacement(state: GameState): GameState {
+        val playableState = requireActiveRound(state)
+        if (playableState.phase != GamePhase.AWAITING_REPLACEMENT) {
+            throw InvalidMoveException("a card has to be drawn before this action")
+        }
+        return playableState
+    }
+
+    private fun replenishDrawPileIfNeeded(state: GameState): GameState {
+        if (state.drawPile.size > 0) {
+            return state
+        }
+
+        if (state.discardPile.size <= 1) {
+            throw InvalidMoveException("cannot replenish draw pile because the discard pile has no spare cards")
+        }
+
+        val protectedTopCard = state.discardPile.topCard()
+        val cardsToShuffle = state.discardPile.cards.dropLast(1)
+        val seed = state.shuffleSeed
+        val random = if (seed != null) {
+            Random(seed + state.shuffleCount.toLong() + 1L)
+        } else {
+            Random
+        }
+        val shuffledCards = cardsToShuffle.shuffled(random)
+
+        return state.copy(
+            drawPile = DrawPile(shuffledCards),
+            discardPile = DiscardPile(listOf(protectedTopCard)),
+            shuffleCount = state.shuffleCount + 1,
+        )
+    }
+
+    private fun advanceAfterTurn(state: GameState): GameState {
+        val currentPlayer = state.currentPlayer()
+        val finisherTriggered = !currentPlayer.board.hasHiddenCards()
+
+        if (state.finisherPlayerId == null && finisherTriggered) {
+            val finalTurns = state.players.size - 1
+            val nextPlayerIndex = nextPlayerIndex(state.currentPlayerIndex, state.players.size)
+            if (finalTurns <= 0) {
+                return finishRound(state.copy(finisherPlayerId = currentPlayer.id, finalTurnsRemaining = 0))
+            }
+
+            return state.copy(
+                currentPlayerIndex = nextPlayerIndex,
+                phase = GamePhase.FINAL_TURNS,
+                finisherPlayerId = currentPlayer.id,
+                finalTurnsRemaining = finalTurns,
+            )
+        }
+
+        if (state.finisherPlayerId != null) {
+            val remainingFinalTurns = state.finalTurnsRemaining - 1
+            if (remainingFinalTurns <= 0) {
+                return finishRound(state.copy(finalTurnsRemaining = 0))
+            }
+
+            return state.copy(
+                currentPlayerIndex = nextPlayerIndex(state.currentPlayerIndex, state.players.size),
+                phase = GamePhase.FINAL_TURNS,
+                finalTurnsRemaining = remainingFinalTurns,
+            )
+        }
+
+        return state.copy(
+            currentPlayerIndex = nextPlayerIndex(state.currentPlayerIndex, state.players.size),
+            phase = GamePhase.AWAITING_DRAW,
+        )
+    }
+
+    internal fun finishRound(state: GameState): GameState {
+        val finisherPlayerId = state.finisherPlayerId ?: throw InvalidMoveException("cannot finish round without a finisher")
+        var updatedDiscardPile = state.discardPile
+        val revealedPlayers = state.players.map { player ->
+            val revealedBoard = player.board.fullyReveal()
+            val cleanupResult = revealedBoard.clearCompletedLines()
+            updatedDiscardPile = updatedDiscardPile.addAll(cleanupResult.removedCards)
+            player.copy(board = cleanupResult.board)
+        }
+
+        val rawScores = revealedPlayers.associate { player -> player.id to player.board.rawScore() }
+        val finisherScore = rawScores.getValue(finisherPlayerId)
+        val mustDoubleFinisher = finisherScore > 0 && rawScores.any { (playerId, score) ->
+            playerId != finisherPlayerId && score <= finisherScore
+        }
+
+        val roundResult = RoundResult(
+            finisherPlayerId = finisherPlayerId,
+            scores = revealedPlayers.map { player ->
+                val rawScore = rawScores.getValue(player.id)
+                RoundResult.PlayerRoundScore(
+                    playerId = player.id,
+                    rawScore = rawScore,
+                    finalScore = when {
+                        player.id == finisherPlayerId && mustDoubleFinisher -> rawScore * 2
+                        else -> rawScore
+                    },
+                )
+            },
+        )
+
+        return state.copy(
+            players = revealedPlayers,
+            discardPile = updatedDiscardPile,
+            phase = GamePhase.ROUND_FINISHED,
+            drawnCard = null,
+            drawSource = null,
+            finalTurnsRemaining = 0,
+            roundResult = roundResult,
+        )
+    }
+
+    internal fun determineStartingPlayerIndex(
+        players: List<PlayerState>,
+        initialReveals: Map<String, Set<BoardPosition>>,
+    ): Int =
+        players.indices.maxByOrNull { index ->
+            players[index].board.visibleValueSum(initialReveals.getValue(players[index].id))
+        } ?: 0
+
+    private fun nextPlayerIndex(currentIndex: Int, playerCount: Int): Int = (currentIndex + 1) % playerCount
+}
+
+private fun <T> List<T>.updated(index: Int, value: T): List<T> = mapIndexed { currentIndex, item ->
+    if (currentIndex == index) value else item
+}

--- a/game/src/test/kotlin/at/aau/se2/skyjo/game/model/BoardLayoutTest.kt
+++ b/game/src/test/kotlin/at/aau/se2/skyjo/game/model/BoardLayoutTest.kt
@@ -1,0 +1,42 @@
+package at.aau.se2.skyjo.game.model
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+
+class BoardLayoutTest {
+    @Test
+    fun numberOfPositionsEqualsRowsTimesColumns() {
+        val expectedTotal = BoardLayout.ROWS * BoardLayout.COLUMNS
+        assertEquals(expectedTotal, BoardLayout.POSITIONS.size)
+        assertEquals(12, BoardLayout.POSITIONS.size)
+    }
+
+    @Test
+    fun verticalLinesAreColumns(){
+        assertEquals(4, BoardLayout.VERTICAL_LINES.size) //wir erwarten 4 Spalten
+        BoardLayout.VERTICAL_LINES.forEach { column -> assertEquals(3, column.size)} //jede Spalte hat drei ReihenElemente
+
+        //erste Reihe wird als Stichprobe geprüft
+        val firstColumn = BoardLayout.VERTICAL_LINES[0]
+        assertEquals(BoardPosition(0,0), firstColumn[0])
+        assertEquals(BoardPosition(1,0), firstColumn[1])
+        assertEquals(BoardPosition(2,0), firstColumn[2])
+    }
+
+    @Test
+    fun horizontalLinesAreRows(){
+        assertEquals(3, BoardLayout.HORIZONTAL_LINES.size) //wir wollen 3 Reihen
+        BoardLayout.HORIZONTAL_LINES.forEach { row -> assertEquals(4, row.size)} //jede Reihe hat 4 SpaltenElemente
+
+        val firstRow = BoardLayout.HORIZONTAL_LINES[0]
+        assertEquals(BoardPosition(0,0), firstRow[0])
+        assertEquals(BoardPosition(0,1), firstRow[1])
+        assertEquals(BoardPosition(0,2), firstRow[2])
+        assertEquals(BoardPosition(0,3), firstRow[3])
+    }
+
+    @Test
+    fun positionsAreUnique(){
+        val uniquePositions = BoardLayout.POSITIONS.distinct().size
+        assertEquals(BoardLayout.POSITIONS.size, uniquePositions)
+    }
+}

--- a/game/src/test/kotlin/at/aau/se2/skyjo/game/model/BoardPositionTest.kt
+++ b/game/src/test/kotlin/at/aau/se2/skyjo/game/model/BoardPositionTest.kt
@@ -1,0 +1,51 @@
+package at.aau.se2.skyjo.game.model
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class BoardPositionTest {
+    @Test
+    fun validPositions() {
+        val minPos =  BoardPosition(0,0)
+        assertEquals(0, minPos.row)
+        assertEquals(0,minPos.column)
+
+        val maxPos =  BoardPosition(BoardLayout.ROWS - 1,BoardLayout.COLUMNS - 1)
+        assertEquals(BoardLayout.COLUMNS - 1 ,maxPos.column)
+        assertEquals(BoardLayout.ROWS - 1,maxPos.row)
+    }
+
+    @Test
+    fun rowNegative(){
+        val exeption = assertThrows<IllegalArgumentException>{ BoardPosition(-1,0) }
+        assertEquals("row must be between 0 and ${BoardLayout.ROWS - 1}", exeption.message)
+    }
+
+    @Test
+    fun rowBiggerThenAllowed(){
+        val exeption = assertThrows<IllegalArgumentException>{ BoardPosition(BoardLayout.ROWS, 0) }
+        assertEquals("row must be between 0 and ${BoardLayout.ROWS - 1}", exeption.message)
+    }
+
+    @Test
+    fun columnNegative(){
+        val exeption = assertThrows<IllegalArgumentException>{ BoardPosition(0,-1) }
+        assertEquals("column must be between 0 and ${BoardLayout.COLUMNS - 1}", exeption.message)
+    }
+
+    @Test
+    fun columnBiggerThenAllowed(){
+        val exception = assertThrows<IllegalArgumentException>{ BoardPosition(0, BoardLayout.COLUMNS) }
+        assertEquals("column must be between 0 and ${BoardLayout.COLUMNS - 1}", exception.message)
+    }
+
+    @Test
+    fun equalityWorks(){
+        val pos1 = BoardPosition(1,2)
+        val pos2 = BoardPosition(1,2)
+        val pos3 = BoardPosition(2,1)
+
+        assertEquals(pos1, pos2)
+        assertNotEquals(pos3, pos1)
+    }
+}

--- a/game/src/test/kotlin/at/aau/se2/skyjo/game/model/BoardSlotTest.kt
+++ b/game/src/test/kotlin/at/aau/se2/skyjo/game/model/BoardSlotTest.kt
@@ -1,0 +1,56 @@
+package at.aau.se2.skyjo.game.model
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class BoardSlotTest {
+
+    @Test
+    fun occupiedAndFaceUpTrue(){
+        val card = SkyjoCard(101, 12) //dummyKarte
+        val slot = BoardSlot.Occupied(card, true)
+
+        assertEquals(card, slot.card)
+        assertTrue(slot.faceUp)
+    }
+
+    @Test
+    fun occupiedAndFaceUpFalse(){
+        val card = SkyjoCard(102, -2)
+        val slot = BoardSlot.Occupied(card, false)
+
+        assertEquals(card, slot.card)
+        assertFalse(slot.faceUp)
+    }
+
+    @Test
+    fun occupiedSlotsDifferentIdSameValue(){
+        val card1 = SkyjoCard(10, 1)
+        val card2 = SkyjoCard(11, 1)
+
+        val slot1 = BoardSlot.Occupied(card1, true)
+        val slot2 = BoardSlot.Occupied(card2, true)
+        assertEquals(card1, slot1.card)
+        assertEquals(card2, slot2.card)
+        assertNotEquals(slot1, slot2)
+    }
+
+    @Test
+    fun occupiedSlotCardChangesFaceUp(){
+        val card1 = SkyjoCard(10, 1)
+        val stateBeforeTurn = BoardSlot.Occupied(card1, false)
+        val stateAfterTurn = BoardSlot.Occupied(card1, true)
+
+        assertNotEquals(stateBeforeTurn, stateAfterTurn)
+    }
+
+    @Test
+    fun clearedIsASingleton(){
+        val slot1 = BoardSlot.Cleared
+        val slot2 = BoardSlot.Cleared
+
+        assertEquals(slot1, slot2) //prüft auf selbe Instanz
+        assertSame(slot1, slot2) //prüft auf selben Speicher
+
+    }
+
+}

--- a/game/src/test/kotlin/at/aau/se2/skyjo/game/model/DiscardPileTest.kt
+++ b/game/src/test/kotlin/at/aau/se2/skyjo/game/model/DiscardPileTest.kt
@@ -1,0 +1,78 @@
+package at.aau.se2.skyjo.game.model
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class DiscardPileTest {
+
+    @Test
+    fun emptyPile(){
+        val pile = DiscardPile.empty()
+        assertEquals(0, pile.size)
+        assertTrue(pile.cards.isEmpty())
+    }
+
+    @Test
+    fun topCardValid(){
+        val card1 = SkyjoCard(1, -2)
+        val card2 = SkyjoCard(2, -2)
+        val pile = DiscardPile(listOf(card1, card2))
+        val top = pile.topCard()
+
+        assertEquals(card2, top)
+        assertEquals(2, pile.size)
+    }
+
+    @Test
+    fun topCardInvalid(){ //weil der Stack leer ist
+        val emptyPile = DiscardPile.empty()
+        val exception = assertThrows<IllegalArgumentException> { emptyPile.topCard() }
+
+        assertEquals("discard pile is empty", exception.message)
+    }
+
+    @Test
+    fun takeTopValid(){
+        val card1 = SkyjoCard(1, -2)
+        val card2 = SkyjoCard(2, -2)
+        val pile = DiscardPile(listOf(card1, card2))
+        val top = pile.takeTop()
+
+        assertEquals(card2, top.card)
+        assertEquals(1, top.remainingPile.size)
+        assertEquals(card1, top.remainingPile.cards.first())
+    }
+
+    @Test
+    fun takeTopInvalid(){
+        val emptyPile = DiscardPile.empty()
+        val exception = assertThrows<IllegalArgumentException> { emptyPile.takeTop() }
+
+        assertEquals("discard pile is empty", exception.message)
+    }
+
+    @Test
+    fun addCard(){
+        val card = SkyjoCard(1, -2)
+        val pile = DiscardPile(listOf(card))
+        val newCard = SkyjoCard(2, -2)
+        val newPile = pile.add(newCard)
+
+        assertEquals(1, pile.size)
+        assertEquals(2, newPile.size)
+        assertEquals(newCard, newPile.topCard())
+    }
+
+    @Test
+    fun addSeveralCards(){
+        val initialCard = SkyjoCard(1, -2)
+        val pile = DiscardPile(listOf(initialCard))
+        val newCards = listOf(SkyjoCard(2, 6), SkyjoCard(3, 12))
+        val newPile = pile.addAll(newCards)
+
+        assertEquals(3, newPile.size)
+        assertEquals(3, newPile.topCard().id)
+        assertEquals(listOf(1,2,3), newPile.cards.map{it.id})
+    }
+
+}

--- a/game/src/test/kotlin/at/aau/se2/skyjo/game/model/DrawPileTest.kt
+++ b/game/src/test/kotlin/at/aau/se2/skyjo/game/model/DrawPileTest.kt
@@ -1,0 +1,34 @@
+package at.aau.se2.skyjo.game.model
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Assertions.*
+
+class DrawPileTest {
+
+    @Test
+    fun emptyPile() {
+        val pile = DrawPile.empty()
+        assertEquals(0, pile.size)
+        assertTrue(pile.cards.isEmpty())
+    }
+
+    @Test
+    fun drawValid(){
+        val card1 = SkyjoCard(1, 2)
+        val card2 = SkyjoCard(2, 10)
+        val pile = DrawPile(listOf(card1, card2))
+        val result = pile.draw()
+
+        assertEquals(card2, result.card)
+        assertEquals(1, result.remainingPile.size)
+        assertEquals(card1, result.remainingPile.cards.first())
+    }
+
+    @Test
+    fun drawInvalid(){ //Stapel ist leer
+        val emptyPile = DrawPile.empty()
+        val exception = assertThrows<IllegalArgumentException>{emptyPile.draw()}
+
+        assertEquals("draw pile is empty", exception.message)
+    }
+}

--- a/game/src/test/kotlin/at/aau/se2/skyjo/game/model/GameStateTest.kt
+++ b/game/src/test/kotlin/at/aau/se2/skyjo/game/model/GameStateTest.kt
@@ -1,0 +1,70 @@
+package at.aau.se2.skyjo.game.model
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class GameStateTest {
+
+    object TestData{ //erstellt Players mit Boards um Korrekt testen zu können
+        private var cardIdCounter = 0
+
+        fun createCard(id: Int = cardIdCounter++, value: Int = 5): SkyjoCard {return SkyjoCard(id = id, value = value) }
+        fun createBoard(fillWith: (BoardPosition) -> BoardSlot = {_ -> BoardSlot.Occupied(createCard(), faceUp = false)}) : PlayerBoard{
+            val slots = BoardLayout.POSITIONS.associateWith{pos -> fillWith(pos)}
+            return PlayerBoard(slots)
+        }
+        fun createPlayer(id: String = "p1") =PlayerState(id = id, board = createBoard())
+        fun createDefaultState(playerCount: Int = 2): GameState{
+            val players = (1..playerCount).map { createPlayer("p$it") }
+            return GameState(players = players, phase = GamePhase.AWAITING_DRAW)
+        }
+    }
+
+
+    @Test
+    fun playerListIsEmpty() {
+        val gameState = GameState(players = emptyList())
+
+        assertNull(gameState.currentPlayerId)
+    }
+
+    @Test
+    fun currentPlayerIdReturnsValidIndex(){
+        val p1 = TestData.createPlayer("player-1")
+        val p2 = TestData.createPlayer("player-2")
+        val state = TestData.createDefaultState().copy(players = listOf(p1, p2), currentPlayerIndex = 1)
+
+        assertEquals("player-2", state.currentPlayerId)
+    }
+
+    @Test
+    fun currentPlayerReturnsValidPlayer(){
+        val p1 = TestData.createPlayer("player-1")
+        val p2 = TestData.createPlayer("player-2")
+        val state = TestData.createDefaultState().copy(players = listOf(p1, p2), currentPlayerIndex = 0)
+        val result = state.currentPlayer()
+
+        assertEquals(p1, result)
+        assertEquals("player-1", result.id)
+    }
+
+    @Test
+    fun currentPlayerThrowsOutOfBoundsException(){
+        val state = GameState(players = emptyList(), currentPlayerIndex = 0)
+
+        assertThrows<IndexOutOfBoundsException> { state.currentPlayer() }
+    }
+
+    @Test
+    fun gameStateChangesStateWithCopy(){
+        val initialState = TestData.createDefaultState(playerCount = 2)
+        val drawnCard = TestData.createCard(id = 99)
+        val newState = initialState.copy(drawnCard = drawnCard, phase = GamePhase.AWAITING_REPLACEMENT)
+
+        assertNull(initialState.drawnCard)
+        assertEquals(drawnCard, newState.drawnCard)
+        assertEquals(99, newState.drawnCard?.id)
+        assertNotEquals(initialState.phase, newState.phase)
+    }
+
+}

--- a/game/src/test/kotlin/at/aau/se2/skyjo/game/model/PlayerBoardTest.kt
+++ b/game/src/test/kotlin/at/aau/se2/skyjo/game/model/PlayerBoardTest.kt
@@ -1,0 +1,243 @@
+package at.aau.se2.skyjo.game.model
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.assertThrows
+
+class PlayerBoardTest {
+    private val pos00 = BoardPosition(0, 0) //standart Testposition und Karten
+    private val card5 = SkyjoCard(100, 5)
+
+
+    private fun createTestBoard(defaultValue: Int = 0, faceUp: Boolean = false): PlayerBoard { //erstellt vollständiges Board
+        val slots = BoardLayout.POSITIONS.associateWith{pos ->
+            val uniqueId = pos.row * BoardLayout.COLUMNS + pos.column
+            BoardSlot.Occupied(SkyjoCard(id = uniqueId, defaultValue), faceUp)
+        }
+        return PlayerBoard(slots)
+    }
+
+    @Test
+    fun positionsDoNotMatchLayout(){
+        val incompleteSlots = mapOf(pos00 to BoardSlot.Occupied(card5, false))
+        val exception = assertThrows<IllegalArgumentException>{PlayerBoard(incompleteSlots)}
+
+        assertEquals("board must define all positions exactly once", exception.message)
+    }
+
+    @Test
+    fun innitValidationWorks(){
+        assertThrows<IllegalArgumentException>{
+            PlayerBoard(emptyMap())
+        }
+    }
+
+    @Test
+    fun slotAtValid(){
+        val board = createTestBoard()
+        val slot = board.slotAt(BoardPosition(0, 0))
+
+        assertTrue(slot is BoardSlot.Occupied)
+    }
+
+    @Test
+    fun hiddenPositionsAndHiddenCards(){
+        val pos = BoardPosition(0, 0)
+        val board = createTestBoard(faceUp = false)
+
+        assertTrue(board.hasHiddenCards())
+        assertEquals(12, board.hiddenPositions().size)
+
+        val revealBoard = board.reveal(pos)
+        assertEquals(11, revealBoard.hiddenPositions().size)
+
+        val slotsWithCleared = BoardLayout.POSITIONS.associateWith{p ->
+            if (p == pos) BoardSlot.Cleared
+            else BoardSlot.Occupied(SkyjoCard(0,0), faceUp = true)
+        }
+        val boardClearedSlots = PlayerBoard(slotsWithCleared)
+        assertEquals(0, boardClearedSlots.hiddenPositions().size) //alle Karten aufgedeckt oder nicht occupied
+    }
+
+    @Test
+    fun revealLogicAndError(){
+        val board = createTestBoard(faceUp = false)
+        val pos = BoardPosition(1, 1)
+        val updatedBoard = board.reveal(pos)
+        val slotsWithCleared = BoardLayout.POSITIONS.associateWith{p ->
+            if (p == pos) BoardSlot.Cleared
+            else BoardSlot.Occupied(SkyjoCard(0,0), faceUp = false)
+        }
+        val boardClearedSlots = PlayerBoard(slotsWithCleared)
+        val exception = assertThrows<IllegalArgumentException>{boardClearedSlots.reveal(pos)}
+
+        assertTrue((updatedBoard.slotAt(pos) as BoardSlot.Occupied).faceUp) //Karte sollte offen sein
+        assertThrows<IllegalArgumentException>{updatedBoard.reveal(pos)} //aufdeken sollte nicht mehr möglich sein, da die Karte schon offen ist
+        assertThrows<IllegalArgumentException>{boardClearedSlots.reveal(pos)} //aufdecken sollte nict möglich sein, da Slot nicht Occupied ist
+        assertEquals("cannot reveal a cleared slot", exception.message)
+    }
+
+    @Test
+    fun replaceLogicAndError(){
+        val pos = BoardPosition(2, 2)
+        val oldCard = SkyjoCard(1, 10)
+        val newCard = SkyjoCard(2, -2)
+        val slots = BoardLayout.POSITIONS.associateWith{
+            if (it == pos) BoardSlot.Occupied(oldCard, false)
+            else BoardSlot.Occupied(SkyjoCard(it.row * 10, 0), false)
+        }
+        val board = PlayerBoard(slots)
+        val result = board.replace(pos, newCard)
+
+        assertEquals(oldCard, result.replacedCard)
+        val newSlot = result.board.slotAt(pos) as BoardSlot.Occupied
+        assertEquals(newCard, newSlot.card)
+        assertTrue(newSlot.faceUp, "Replaced cards must be face up")
+
+        val slotsWithCleared = BoardLayout.POSITIONS.associateWith{p ->
+            if (p == pos) BoardSlot.Cleared
+            else BoardSlot.Occupied(SkyjoCard(0,0), faceUp = false)
+        }
+        val boardClearedSlots = PlayerBoard(slotsWithCleared)
+        val exception  = assertThrows<IllegalArgumentException>{boardClearedSlots.replace(pos, newCard)}
+        assertThrows<IllegalArgumentException>{boardClearedSlots.replace(pos, newCard)}
+        assertEquals("cannot replace a cleared slot", exception.message)
+    }
+
+    @Test
+    fun fullyRevealValid(){
+        val hiddenPos = BoardPosition(0, 0)
+        val openPos = BoardPosition(1, 0)
+        val card1 = SkyjoCard(1, 5)
+        val card2 = SkyjoCard(2, 0)
+        val slots = BoardLayout.POSITIONS.associateWith{p ->    //es gibt jeweils eine offene und eine geschlossene Karte
+            when (p){
+                hiddenPos -> BoardSlot.Occupied(card1, faceUp = false)
+                openPos -> BoardSlot.Occupied(card2, faceUp = true)
+                else -> BoardSlot.Cleared
+            }
+        }
+        val board = PlayerBoard(slots)
+        val revealedBoard = board.fullyReveal()
+        val slotHidden = revealedBoard.slotAt(hiddenPos) as BoardSlot.Occupied
+        val slotOpen = revealedBoard.slotAt(openPos) as BoardSlot.Occupied
+
+        assertTrue(slotHidden.faceUp)
+        assertEquals(5, slotHidden.card.value)
+        assertTrue(slotOpen.faceUp)
+        assertEquals(0, slotOpen.card.value)
+        assertFalse(revealedBoard.hasHiddenCards()) //testet ob alles offen ist
+    }
+
+    @Test
+    fun rawScoreValid(){
+        val pos = BoardPosition(0, 0)
+        val board = createTestBoard(defaultValue = 5)
+        val slotsWithCleared = BoardLayout.POSITIONS.associateWith{p ->
+            if (p == pos) BoardSlot.Cleared
+            else BoardSlot.Occupied(SkyjoCard(0, 5), faceUp = true)
+        }
+        val boardClearedSlots = PlayerBoard(slotsWithCleared)
+
+        assertEquals(60, board.rawScore()) //12 Karten *5 sollte 60 sein
+        assertEquals(55, boardClearedSlots.rawScore()) //eine karte ist weniger, wert 0
+    }
+
+    @Test
+    fun visibleValueSumValid(){
+        val pos = BoardPosition(2, 2)
+        val pos1 = BoardPosition(1, 2)
+        val board = createTestBoard(defaultValue = 10, faceUp = true)
+        val hiddenBoard = createTestBoard(faceUp = false)
+        val slotsWithCleared = BoardLayout.POSITIONS.associateWith{p ->
+            if (p == pos) BoardSlot.Cleared
+            else BoardSlot.Occupied(SkyjoCard(0,0), faceUp = true)
+        }
+        val boardClearedSlots = PlayerBoard(slotsWithCleared)
+
+        assertEquals(20, board.visibleValueSum(setOf(pos, pos1)))
+        assertThrows<IllegalArgumentException>{hiddenBoard.visibleValueSum(setOf(pos, pos1))}
+        assertThrows<IllegalArgumentException>{boardClearedSlots.visibleValueSum(setOf(pos, pos1))}
+    }
+
+    @Test
+    fun clearCompletedLinesRemovesColumn(){
+        val targetColumn = 0
+        val slots = BoardLayout.POSITIONS.associateWith{p ->
+            val isMatch = p.column == targetColumn
+            BoardSlot.Occupied(SkyjoCard(p.row * 10 + p.column, if(isMatch) 1 else 2), faceUp = isMatch)
+        }
+        val board = PlayerBoard(slots)
+        val result = board.clearCompletedLines()
+
+        assertEquals(3, result.removedCards.size)
+        assertTrue(result.removedCards.all{it.value == 1})
+        BoardLayout.VERTICAL_LINES[targetColumn].forEach{p ->
+            assertTrue(result.board.slotAt(p) is BoardSlot.Cleared)
+        }
+    }
+
+    @Test
+    fun clearCompletedLinesButNoMatches(){
+        val targetColumn = 1
+        val slots1 = BoardLayout.POSITIONS.associateWith{p ->
+            val isMatch = p.column == targetColumn
+            val isFaceUp = isMatch && p.row != 1
+            BoardSlot.Occupied(SkyjoCard(p.row * 10 + p.column, 1), faceUp = isFaceUp)
+        }
+        val board1 = PlayerBoard(slots1)
+        val result1 = board1.clearCompletedLines()
+
+        assertTrue(result1.removedCards.isEmpty())
+        assertEquals(board1, result1.board)
+
+        val slots2 = BoardLayout.POSITIONS.associateWith{p ->
+            BoardSlot.Occupied(SkyjoCard(p.row * 10 + p.column, p.row + p.column), faceUp = true)
+        }
+        val board2 = PlayerBoard(slots2)
+        val result2 = board2.clearCompletedLines()
+
+        assertTrue(result2.removedCards.isEmpty())
+        assertEquals(board2, result2.board)
+
+        val slots3 = BoardLayout.POSITIONS.associateWith{BoardSlot.Cleared}
+        val board3 = PlayerBoard(slots3)
+        val result3 = board3.clearCompletedLines()
+        assertTrue(result3.removedCards.isEmpty())
+        assertEquals(0, result3.board.slots.values.filterIsInstance<BoardSlot.Occupied>().size)
+    }
+
+    @Test
+    fun fromCardsExpectsTwoOpenCards(){
+        val cards = List(12){SkyjoCard(it, it)}
+        val revealed = setOf(BoardPosition(0, 0), BoardPosition(1, 0))
+        val board = PlayerBoard.fromCards(cards, revealed)
+
+        assertTrue((board.slotAt(BoardPosition(0,0)) as BoardSlot.Occupied).faceUp)
+        assertTrue((board.slotAt(BoardPosition(1,0)) as BoardSlot.Occupied).faceUp)
+        assertFalse((board.slotAt(BoardPosition(1,1)) as BoardSlot.Occupied).faceUp)
+    }
+
+    @Test
+    fun fromCardsExceptions(){
+        val elevenCards = List(11){SkyjoCard(it, it)}
+        val validRevealed = setOf(BoardPosition(0, 0), BoardPosition(1, 0))
+        val exception = assertThrows<IllegalArgumentException>{
+            PlayerBoard.fromCards(elevenCards, validRevealed)
+        }
+        assertEquals("a player board requires exactly 12 cards", exception.message)
+
+        val twelveCards = List(12){SkyjoCard(it, it)}
+        val onePos = setOf(BoardPosition(0, 0))
+        val threePos = setOf(BoardPosition(1, 0), BoardPosition(0, 1), BoardPosition(1, 1))
+        val ex1 = assertThrows<IllegalArgumentException>{
+            PlayerBoard.fromCards(twelveCards, onePos)
+        }
+        val ex2 = assertThrows<IllegalArgumentException>{
+            PlayerBoard.fromCards(twelveCards, threePos)
+        }
+
+        assertEquals("exactly two initial reveal positions are required", ex1.message)
+        assertEquals("exactly two initial reveal positions are required", ex2.message)
+
+    }
+}

--- a/game/src/test/kotlin/at/aau/se2/skyjo/game/model/SkyjoDeckFactoryTest.kt
+++ b/game/src/test/kotlin/at/aau/se2/skyjo/game/model/SkyjoDeckFactoryTest.kt
@@ -1,0 +1,58 @@
+package at.aau.se2.skyjo.game.model
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+
+class SkyjoDeckFactoryTest {
+    @Test
+    fun cardDistributionMakes150Cards(){
+        val drawPile = SkyjoDeckFactory.createShuffledDrawPile()
+
+        assertEquals(150, drawPile.cards.size)
+    }
+
+    @Test
+    fun cardDistributionIsCorrect(){
+        val drawPile = SkyjoDeckFactory.createShuffledDrawPile()
+        val cards = drawPile.cards
+        val counts = cards.groupingBy { it.value }.eachCount()
+
+        assertEquals(5, counts[-2])
+        assertEquals(10, counts[-1])
+        assertEquals(15, counts[0])
+        for (value in 1..12){assertEquals(10, counts[value])}
+    }
+
+    @Test
+    fun cardsHaveUniqueId(){
+        val drawPile = SkyjoDeckFactory.createShuffledDrawPile()
+        val ids = drawPile.cards.map{it.id}
+
+        assertEquals(150, ids.toSet().size) //toSet entfehrnt Duplikate
+        assertTrue(ids.all{it in 1..150})
+    }
+
+    @Test
+    fun shuffleWithSameSeed(){
+        val seed = 42L
+        val pile1 = SkyjoDeckFactory.createShuffledDrawPile(seed)
+        val pile2 = SkyjoDeckFactory.createShuffledDrawPile(seed)
+
+        assertEquals(pile1.cards, pile2.cards)
+    }
+
+    @Test
+    fun shuffleWithDifferentSeed(){
+        val pile1 = SkyjoDeckFactory.createShuffledDrawPile(123L)
+        val pile2 = SkyjoDeckFactory.createShuffledDrawPile(456L)
+
+        assertNotEquals(pile1.cards, pile2.cards)
+    }
+
+    @Test
+    fun shuffleWithoutSeed(){
+        val pile1 = SkyjoDeckFactory.createShuffledDrawPile()
+        val pile2 = SkyjoDeckFactory.createShuffledDrawPile()
+
+        assertNotEquals(pile1.cards, pile2.cards)
+    }
+}

--- a/game/src/test/kotlin/at/aau/se2/skyjo/game/service/SkyjoEngineTest.kt
+++ b/game/src/test/kotlin/at/aau/se2/skyjo/game/service/SkyjoEngineTest.kt
@@ -1,0 +1,898 @@
+package at.aau.se2.skyjo.game.service
+
+import at.aau.se2.skyjo.game.error.*
+import at.aau.se2.skyjo.game.model.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
+
+
+
+class SkyjoEngineTest {
+    private lateinit var engine: SkyjoEngine
+
+    @BeforeEach
+    fun setUp() {
+        engine = SkyjoEngine()
+    }
+
+    @Nested
+    inner class StartGameTest{
+        @Test
+        fun playerCountInvalidTooLow(){
+            val playerIds = listOf("p1")
+            val initialReveals = mapOf("p1" to setOf(mockPosition(),mockPosition()))
+            val exception = assertThrows<InvalidGameSetupException>{engine.startGame(playerIds,initialReveals)}
+
+            assertThat(exception).hasMessageContaining("between 2 and 8 players")
+        }
+
+        @Test
+        fun playerCountInvalidTooHigh(){
+            val playerIds = listOf("p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9")
+            val initialReveals = mapOf(
+                "p1" to setOf(mockPosition(),mockPosition()),
+                "p2" to setOf(mockPosition(),mockPosition()),
+                "p3" to setOf(mockPosition(),mockPosition()),
+                "p4" to setOf(mockPosition(),mockPosition()),
+                "p5" to setOf(mockPosition(),mockPosition()),
+                "p6" to setOf(mockPosition(),mockPosition()),
+                "p7" to setOf(mockPosition(),mockPosition()),
+                "p8" to setOf(mockPosition(),mockPosition()),
+                "p9" to setOf(mockPosition(),mockPosition()))
+            val exception = assertThrows<InvalidGameSetupException>{engine.startGame(playerIds,initialReveals)}
+
+            assertThat(exception).hasMessageContaining("between 2 and 8 players")
+        }
+
+        @Test
+        fun initialRevealsNotComplete(){
+            val playerIds = listOf("p1", "p2")
+            val initialReveals = mapOf("p1" to setOf(mockPosition(),mockPosition()))
+            val exception = assertThrows<InvalidGameSetupException>{engine.startGame(playerIds,initialReveals)}
+
+            assertThat(exception).hasMessageContaining("initial reveals must be provided for every player id")
+        }
+
+        @Test
+        fun startGameWorksCorrectly(){
+            val playerIds = listOf("p1", "p2")
+            val initialReveals = mapOf(
+                "p1" to setOf(mockPosition(0,0),mockPosition(0,2)),
+                "p2" to setOf(mockPosition(1,1),mockPosition(2,2)),
+            )
+            val seed = 42L
+            val state = engine.startGame(playerIds,initialReveals,seed)
+
+            assertThat(state.players).hasSize(2)
+            assertThat(state.phase).isEqualTo(GamePhase.AWAITING_DRAW)
+            assertThat(state.discardPile.size).isEqualTo(1)
+            assertThat(state.shuffleSeed).isEqualTo(seed)
+        }
+    }
+    @Nested
+    inner class DrawFromDeckTest{
+        @Test
+        fun drawFromDeckChangesPhaseFromAwaitingDraw(){
+            val initialState = mockGameState(phase = GamePhase.AWAITING_DRAW, drawPile = DrawPile(cards = listOf(mockCard(), mockCard(), mockCard(), mockCard())))
+            val initialDrawPileSize = initialState.drawPile.size
+            val newState = engine.drawFromDeck(initialState)
+
+            assertThat(newState.phase).isEqualTo(GamePhase.AWAITING_REPLACEMENT)
+            assertThat(newState.drawSource).isEqualTo(DrawSource.DECK)
+            assertThat(newState.drawnCard).isNotNull
+            assertThat(newState.drawPile.size).isEqualTo(initialDrawPileSize - 1)
+        }
+
+        @Test
+        fun drawFromDeckChangesPhaseFromFinalTurns(){
+            val initialState = mockGameState(phase = GamePhase.FINAL_TURNS, drawPile = DrawPile(cards = listOf(mockCard(), mockCard(), mockCard(), mockCard())))
+            val initialDrawPileSize = initialState.drawPile.size
+            val newState = engine.drawFromDeck(initialState)
+
+            assertThat(newState.phase).isEqualTo(GamePhase.AWAITING_REPLACEMENT)
+            assertThat(newState.drawSource).isEqualTo(DrawSource.DECK)
+            assertThat(newState.drawnCard).isNotNull
+            assertThat(newState.drawPile.size).isEqualTo(initialDrawPileSize - 1)
+        }
+
+        @Test
+        fun drawFromDeckWrongPhase(){
+            val initialState = mockGameState(phase = GamePhase.AWAITING_REPLACEMENT, drawPile = DrawPile(cards = listOf(mockCard(), mockCard(), mockCard(), mockCard())))
+            val exception = assertThrows<InvalidMoveException>{engine.drawFromDeck(initialState)}
+
+            assertThat(exception).hasMessageContaining("cannot draw from deck while phase is")
+
+        }
+    }
+
+    @Nested
+    inner class TakeDiscardTest{
+        @Test
+        fun cardOnTopIsTakenPhaseAwaitingDraw(){
+            val topDiscardCard = mockCard(value = 5)
+            val initialState = mockGameState(phase = GamePhase.AWAITING_DRAW, discardPile = DiscardPile(cards = listOf(mockCard(value = -1), topDiscardCard)))
+            val newState = engine.takeDiscardCard(initialState)
+
+            assertThat(newState.phase).isEqualTo(GamePhase.AWAITING_REPLACEMENT)
+            assertThat(newState.drawSource).isEqualTo(DrawSource.DISCARD)
+            assertThat(newState.drawnCard).isEqualTo(topDiscardCard)
+            assertThat(newState.discardPile.size).isEqualTo(1)
+        }
+
+        @Test
+        fun cardOnTopIsTakenPhaseFinalTurns(){
+            val topDiscardCard = mockCard(value = 5)
+            val initialState = mockGameState(phase = GamePhase.FINAL_TURNS, discardPile = DiscardPile(cards = listOf(mockCard(value = -1), topDiscardCard)))
+            val newState = engine.takeDiscardCard(initialState)
+
+            assertThat(newState.phase).isEqualTo(GamePhase.AWAITING_REPLACEMENT)
+            assertThat(newState.drawSource).isEqualTo(DrawSource.DISCARD)
+            assertThat(newState.drawnCard).isEqualTo(topDiscardCard)
+            assertThat(newState.discardPile.size).isEqualTo(1)
+        }
+
+        @Test
+        fun cardOnTopIsTakenWrongPhase(){
+            val initialState = mockGameState(phase = GamePhase.AWAITING_REPLACEMENT)
+
+            val exception = assertThrows<InvalidMoveException>{engine.takeDiscardCard(initialState)}
+            assertThat(exception).hasMessageContaining("cannot take discard card while phase is")
+        }
+    }
+
+    @Nested
+    inner class ReplaceDrawnCardTets{
+        @Test
+        fun replaceDrawnCardWorks(){
+            val drawnCard = mockCard(1, 5)
+            val initialState = mockGameState(
+                phase = GamePhase.AWAITING_REPLACEMENT,
+                drawnCard = drawnCard,
+                drawSource = DrawSource.DECK,
+                currentPlayerIndex = 0
+            )
+            val targetPosition = mockPosition()
+            val newState = engine.replaceDrawnCard(initialState, targetPosition)
+
+            assertThat(newState.phase).isEqualTo(GamePhase.AWAITING_DRAW)
+            assertThat(newState.drawSource).isNull()
+            assertThat(newState.drawnCard).isNull()
+            assertThat(newState.discardPile.size).isEqualTo(1)
+        }
+
+        @Test
+        fun noDrawnCard(){
+            val initialState = mockGameState(
+                phase = GamePhase.AWAITING_REPLACEMENT,
+                drawSource = DrawSource.DECK,
+                currentPlayerIndex = 0 //keine DrawnCard (standartmäßig 0)
+            )
+            val targetPosition = mockPosition()
+            val exception = assertThrows<InvalidMoveException>{engine.replaceDrawnCard(initialState, targetPosition)}
+            assertThat(exception).hasMessageContaining("no drawn card is available")
+        }
+    }
+
+    @Nested
+    inner class DiscardDrawnCardAndRevealTest{
+        @Test
+        fun cardNotFromDrawDeck(){
+            val initialState = mockGameState(
+                phase = GamePhase.AWAITING_REPLACEMENT,
+                drawSource = DrawSource.DISCARD //löst Fehler aus
+            )
+            val targetPosition = mockPosition()
+
+            val exception = assertThrows<InvalidMoveException>{engine.discardDrawnCardAndReveal(initialState, targetPosition)}
+            assertThat(exception).hasMessageContaining("discard and reveal is only allowed after drawing from the deck")
+        }
+        @Test
+        fun noDrawnCard(){
+            val initialState = mockGameState(
+                phase = GamePhase.AWAITING_REPLACEMENT,
+                drawSource = DrawSource.DECK
+            )
+            val targetPosition = mockPosition()
+
+            val exception = assertThrows<InvalidMoveException> {engine.discardDrawnCardAndReveal(initialState, targetPosition)}
+            assertThat(exception).hasMessageContaining("no drawn card is available")
+        }
+
+        @Test
+        fun slotIsFaceUpOrCleared(){
+            val targetPosition = mockPosition()
+            val drawnCard = mockCard(1, 5)
+            val boardFaceUp = mockPlayerBoard(faceUp = true)
+            val boardCleared = mockPlayerBoardMissingColumn()
+            val initialStateFaceUp = mockGameState( //alle Karten sind FaceUp -> Fehler
+                players = listOf(mockPlayer(board = boardFaceUp), mockPlayer(board = boardFaceUp)),
+                phase = GamePhase.AWAITING_REPLACEMENT,
+                drawSource = DrawSource.DECK,
+                drawnCard = drawnCard
+            )
+            val initialStateCleared = mockGameState(
+                players = listOf(mockPlayer(board = boardCleared), mockPlayer(board = boardCleared)),
+                phase = GamePhase.AWAITING_REPLACEMENT,
+                drawSource = DrawSource.DECK,
+                drawnCard = drawnCard
+            )
+
+            val exceptionFaceUp = assertThrows<InvalidMoveException> {engine.discardDrawnCardAndReveal(initialStateFaceUp, targetPosition)}
+            assertThat(exceptionFaceUp).hasMessageContaining("discard and reveal requires a face-down occupied slot")
+
+            val exceptionCleared = assertThrows<InvalidMoveException> {engine.discardDrawnCardAndReveal(initialStateCleared, targetPosition)}
+            assertThat(exceptionCleared).hasMessageContaining("discard and reveal requires a face-down occupied slot")
+        }
+
+
+
+        @Test
+        fun allWorks(){
+            val targetPosition = mockPosition()
+            val drawnCard = mockCard(1, 5)
+            val initialState = mockGameState(
+                phase = GamePhase.AWAITING_REPLACEMENT,
+                drawSource = DrawSource.DECK,
+                drawnCard = drawnCard
+            )
+            val newState = engine.discardDrawnCardAndReveal(initialState, targetPosition)
+
+            assertThat(newState.phase).isEqualTo(GamePhase.AWAITING_DRAW)
+            assertThat(newState.drawSource).isNull()
+            assertThat(newState.drawnCard).isNull()
+            assertThat(newState.discardPile.size).isEqualTo(1)
+            assertThat(newState.discardPile.topCard()).isEqualTo(drawnCard)
+        }
+    }
+
+    @Nested
+    inner class ValidateSetupTest {
+
+        @Test
+        fun tooFewPlayers() {
+            val playerIds = listOf("p1")
+            val initialReveals = mapOf(
+                "p1" to setOf(mockPosition(0, 0), mockPosition(0, 1))
+            )
+
+            val exception = assertThrows<InvalidGameSetupException> {
+                engine.startGame(playerIds, initialReveals)
+            }
+            assertTrue(exception.message!!.contains("between 2 and 8 players"))
+        }
+
+        @Test
+        fun tooManyPlayers() {
+            val playerIds = (1..9).map { "p$it" }
+            val initialReveals = playerIds.associateWith {
+                setOf(mockPosition(0, 0), mockPosition(0, 1))
+            }
+
+            val exception = assertThrows<InvalidGameSetupException> {
+                engine.startGame(playerIds, initialReveals)
+            }
+            assertTrue(exception.message!!.contains("between 2 and 8 players"))
+        }
+
+        @Test
+        fun noUniqueIDs() {
+            val playerIds = listOf("p1", "p2", "p1") // "p1" ist doppelt
+            val initialReveals = mapOf(
+                "p1" to setOf(mockPosition(0, 0), mockPosition(0, 1)),
+                "p2" to setOf(mockPosition(1, 0), mockPosition(1, 1))
+            )
+
+            val exception = assertThrows<InvalidGameSetupException> {
+                engine.startGame(playerIds, initialReveals)
+            }
+            assertTrue(exception.message!!.contains("player ids must be unique"))
+        }
+
+        @Test
+        fun blankIDs() {
+            val playerIds = listOf("p1", "   ") // Blank ID
+            val initialReveals = mapOf(
+                "p1" to setOf(mockPosition(0, 0), mockPosition(0, 1)),
+                "   " to setOf(mockPosition(1, 0), mockPosition(1, 1))
+            )
+
+            val exception = assertThrows<InvalidGameSetupException> {
+                engine.startGame(playerIds, initialReveals)
+            }
+            assertTrue(exception.message!!.contains("player ids must not be blank"))
+        }
+
+        @Test
+        fun missingReveals() {
+            val playerIds = listOf("p1", "p2")
+            // Reveal für "p2" fehlt
+            val initialReveals = mapOf(
+                "p1" to setOf(mockPosition(0, 0), mockPosition(0, 1))
+            )
+
+            val exception = assertThrows<InvalidGameSetupException> {
+                engine.startGame(playerIds, initialReveals)
+            }
+            assertTrue(exception.message!!.contains("initial reveals must be provided for every player id"))
+        }
+
+        @Test
+        fun unknownID() {
+            val playerIds = listOf("p1", "p2")
+            val initialReveals = mapOf(
+                "p1" to setOf(mockPosition(0, 0), mockPosition(0, 1)),
+                "p2" to setOf(mockPosition(1, 0), mockPosition(1, 1)),
+                "p3" to setOf(mockPosition(2, 0), mockPosition(2, 1)) // p3 spielt gar nicht mit
+            )
+
+            val exception = assertThrows<InvalidGameSetupException> {
+                engine.startGame(playerIds, initialReveals)
+            }
+            assertTrue(exception.message!!.contains("initial reveals must be provided for every player id"))
+        }
+
+        @Test
+        fun notEnoughRevealsPerPlayer() {
+            val playerIds = listOf("p1", "p2")
+            val initialReveals = mapOf(
+                "p1" to setOf(mockPosition(0, 0)), // Nur 1 Position!
+                "p2" to setOf(mockPosition(1, 0), mockPosition(1, 1))
+            )
+
+            val exception = assertThrows<InvalidGameSetupException> {
+                engine.startGame(playerIds, initialReveals)
+            }
+            assertTrue(exception.message!!.contains("each player must reveal exactly two positions"))
+        }
+
+        @Test
+        fun tooManyRevealsPerPlayer() {
+            val playerIds = listOf("p1", "p2")
+            val initialReveals = mapOf(
+                "p1" to setOf(mockPosition(0, 0), mockPosition(0, 1), mockPosition(0, 2)), // 3 Positionen!
+                "p2" to setOf(mockPosition(1, 0), mockPosition(1, 1))
+            )
+
+            val exception = assertThrows<InvalidGameSetupException> {
+                engine.startGame(playerIds, initialReveals)
+            }
+            assertTrue(exception.message!!.contains("each player must reveal exactly two positions"))
+        }
+    }
+
+    @Nested
+    inner class RequireActiveRoundTest {
+
+        @Test
+        fun gameNotStarted() {
+            val state = mockGameState(phase = GamePhase.NOT_STARTED)
+
+            assertThrows<GameNotStartedException> { engine.drawFromDeck(state) }
+        }
+
+        @Test
+        fun roundIsFinished() {
+            val state = mockGameState(phase = GamePhase.ROUND_FINISHED)
+
+
+            assertThrows<RoundAlreadyFinishedException> { engine.takeDiscardCard(state) }
+        }
+
+        @Test
+        fun awaitingDraw() {
+            val state = mockGameState(phase = GamePhase.AWAITING_DRAW, drawPile = DrawPile(cards = listOf(mockCard(), mockCard())))
+            val result = engine.drawFromDeck(state)
+
+            assertEquals(GamePhase.AWAITING_REPLACEMENT, result.phase)
+        }
+
+        @Test
+        fun finalTurns() {
+            val state = mockGameState(phase = GamePhase.FINAL_TURNS, drawPile = DrawPile(cards = listOf(mockCard(), mockCard())))
+            val result = engine.drawFromDeck(state)
+
+            assertEquals(GamePhase.AWAITING_REPLACEMENT, result.phase)
+        }
+    }
+
+    @Nested
+    inner class RequireAwaitingReplacementTest {
+
+        @Test
+        fun awaitingDraw() {
+            val state = mockGameState(phase = GamePhase.AWAITING_DRAW)
+            val pos = mockPosition()
+
+            val exception = assertThrows<InvalidMoveException> {
+                engine.replaceDrawnCard(state, pos)
+            }
+            assertTrue(exception.message!!.contains("a card has to be drawn before this action"))
+        }
+
+        @Test
+        fun finalTurns() {
+            val state = mockGameState(phase = GamePhase.FINAL_TURNS)
+            val pos = mockPosition()
+
+            val exception = assertThrows<InvalidMoveException> {
+               engine.replaceDrawnCard(state, pos)
+            }
+            assertTrue(exception.message!!.contains("a card has to be drawn before this action"))
+        }
+
+
+        @Test
+        fun notStarted() {
+            val state = mockGameState(phase = GamePhase.NOT_STARTED)
+            val pos = mockPosition()
+
+            assertThrows<GameNotStartedException> {
+                engine.replaceDrawnCard(state, pos)
+            }
+        }
+
+        @Test
+        fun roundFinished() {
+            val state = mockGameState(phase = GamePhase.ROUND_FINISHED)
+            val pos = mockPosition()
+
+            assertThrows<RoundAlreadyFinishedException> {
+                engine.replaceDrawnCard(state, pos)
+            }
+        }
+    }
+
+    @Nested
+    inner class ReplenishDrawPileIfNeededTests {
+
+        @Test
+        fun drawPileFull() {
+            val state = mockGameState(
+                phase = GamePhase.AWAITING_DRAW,
+                drawPile = DrawPile(listOf(mockCard(id = 1))),
+                discardPile = DiscardPile(listOf(mockCard(id = 2), mockCard(id = 3)))
+            )
+            val result = engine.drawFromDeck(state)
+
+            assertEquals(result.phase, GamePhase.AWAITING_REPLACEMENT) //war erfolgreich, nächste phase
+        }
+
+        @Test
+        fun emptyDeckEmptyDiscard() {
+            val state = mockGameState(
+                phase = GamePhase.AWAITING_DRAW,
+                drawPile = DrawPile.empty(),
+                discardPile = DiscardPile(listOf(mockCard(id = 1)))
+            )
+            val exception = assertThrows<InvalidMoveException> {
+                engine.drawFromDeck(state)
+            }
+            assertTrue(exception.message!!.contains("discard pile has no spare cards"))
+        }
+
+        @Test
+        fun replenishesDrawPile() {
+            val card1 = mockCard(id = 1)
+            val card2 = mockCard(id = 2)
+            val topCard = mockCard(id = 3) // Diese muss auf dem Ablagestapel bleiben
+            val state = mockGameState(
+                phase = GamePhase.AWAITING_DRAW,
+                drawPile = DrawPile.empty(),
+                discardPile = DiscardPile(listOf(card1, card2, mockCard(), topCard)),
+                shuffleCount = 0
+            )
+            val result = engine.drawFromDeck(state)
+
+            assertEquals(2, result.drawPile.size) // card1 und card2 wurden gemischt
+            assertEquals(1, result.discardPile.size) // Nur noch die topCard ist da
+            assertEquals(topCard, result.discardPile.cards.last()) // Prüft, ob die richtige Karte geschützt wurde
+            assertEquals(1, result.shuffleCount) // Count wurde hochgezählt
+        }
+
+        @Test
+        fun shuffelsCardsCorrectly() {
+            val cards = List(10) { mockCard(id = it) }
+            val topCard = mockCard(id = 99)
+            val state1 = mockGameState(
+                phase = GamePhase.AWAITING_DRAW,
+                drawPile = DrawPile.empty(),
+                discardPile = DiscardPile(cards + topCard),
+                shuffleSeed = 42L,
+                shuffleCount = 2
+            )
+            // Ein exakter Klon des States, um zu prüfen, ob das Mischen identisch abläuft
+            val state2 = mockGameState(
+                phase = GamePhase.AWAITING_DRAW,
+                drawPile = DrawPile.empty(),
+                discardPile = DiscardPile(cards + topCard),
+                shuffleSeed = 42L,
+                shuffleCount = 2
+            )
+            val result1 = engine.drawFromDeck(state1)
+            val result2 = engine.drawFromDeck(state2)
+
+            assertEquals(result1.drawPile.cards, result2.drawPile.cards)
+        }
+    }
+
+    @Nested
+    inner class AdvanceAfterTurnTest {
+
+        @Test
+        fun advancesToAwaitingDraw() {
+            //Normaler Spielzug, Spieler 1 hat noch verdeckte Karten (faceUp = false)
+            val p1 = mockPlayer("p1", mockPlayerBoard(faceUp = false))
+            val p2 = mockPlayer("p2", mockPlayerBoard(faceUp = false))
+            val drawnCard = mockCard()
+            val lastPos = mockPosition(0,0)
+            val state = mockGameState(
+                phase = GamePhase.AWAITING_REPLACEMENT,
+                drawSource = DrawSource.DECK,
+                drawnCard = drawnCard,
+                players = listOf(p1, p2),
+                currentPlayerIndex = 0 // p1 ist dran
+            )
+            val result = engine.discardDrawnCardAndReveal(state, lastPos)
+
+
+            assertEquals(1, result.currentPlayerIndex) // p2 ist als nächstes dran
+            assertEquals(GamePhase.AWAITING_DRAW, result.phase)
+            assertNull(result.finisherPlayerId)
+        }
+
+        @Test
+        fun finalTurnsAfterAllCardsOpen() {
+            //Spieler 1 hat soeben seine letzte Karte aufgedeckt (faceUp = true)
+            val p1 = mockPlayer("p1", mockPlayerBoardOneFaceDown())
+            val p2 = mockPlayer("p2", mockPlayerBoard(faceUp = false))
+            val lastPos = mockPosition(0,0)
+            val state = mockGameState(
+                phase = GamePhase.AWAITING_REPLACEMENT,
+                drawSource = DrawSource.DECK,
+                drawnCard = mockCard(),
+                players = listOf(p1, p2),
+                currentPlayerIndex = 0,
+                finisherPlayerId = null
+            )
+            val result = engine.discardDrawnCardAndReveal(state, lastPos)
+
+            assertEquals(1, result.currentPlayerIndex) // p2 ist dran
+            assertEquals(GamePhase.FINAL_TURNS, result.phase)
+            assertEquals("p1", result.finisherPlayerId) // p1 hat das Ende eingeleitet
+            assertEquals(1, result.finalTurnsRemaining) // Bei 2 Spielern bleibt noch 1 Zug
+        }
+
+        @Test
+        fun decrementsFinalTurnsRemaining() {
+            // p1 hat das Ende eingeleitet, wir sind in den letzten Zügen.
+            // 3 Spieler insgesamt, p2 hat seinen Zug beendet.
+            val p1 = mockPlayer("p1", mockPlayerBoard(faceUp = true))
+            val p2 = mockPlayer("p2", mockPlayerBoard(faceUp = false))
+            val p3 = mockPlayer("p3", mockPlayerBoard(faceUp = false))
+            val pos = mockPosition(0,0)
+            val drawnCard = mockCard()
+            val state = mockGameState(
+                drawSource = DrawSource.DECK,
+                drawnCard = drawnCard,
+                players = listOf(p1, p2, p3),
+                currentPlayerIndex = 1, // p2 war gerade dran
+                finisherPlayerId = "p1",
+                finalTurnsRemaining = 2, // p2 und p3 durften noch
+                phase = GamePhase.AWAITING_REPLACEMENT
+            )
+            val result = engine.discardDrawnCardAndReveal(state, pos)
+
+            assertEquals(2, result.currentPlayerIndex) // p3 ist nun dran
+            assertEquals(GamePhase.FINAL_TURNS, result.phase)
+            assertEquals(1, result.finalTurnsRemaining) // Nur noch p3 darf
+        }
+
+        @Test
+        fun finalTurnsRemainingReaches0() {
+            // p1 hat das Ende eingeleitet. p2 macht seinen letzten Zug.
+            val p1 = mockPlayer("p1", mockPlayerBoard(faceUp = true))
+            val p2 = mockPlayer("p2", mockPlayerBoard(faceUp = false))
+            val pos = mockPosition()
+
+            val state = mockGameState(
+                drawSource = DrawSource.DECK,
+                drawnCard = mockCard(),
+                players = listOf(p1, p2),
+                currentPlayerIndex = 1, // p2 war gerade dran
+                finisherPlayerId = "p1",
+                finalTurnsRemaining = 1, // Dies war der letzte mögliche Zug
+                phase = GamePhase.AWAITING_REPLACEMENT
+            )
+
+            val result = engine.discardDrawnCardAndReveal(state, pos)
+
+            // Then: Wir prüfen, ob die Phase auf ROUND_FINISHED gesprungen ist.
+            // Das beweist, dass die finishRound() Methode aufgerufen wurde.
+            assertEquals(GamePhase.ROUND_FINISHED, result.phase)
+            assertEquals(0, result.finalTurnsRemaining)
+        }
+
+        @Test
+        fun edgeCaseOnePlayer() {
+            // Dieser Test simuliert einen Edge-Case, der durch die Validierung eigentlich verhindert wird, aber den logischen Zweig "finalTurns <= 0" abdeckt.
+            // Nur ein Spieler, der gerade seine letzte Karte aufgedeckt hat
+            val p1 = mockPlayer("p1", mockPlayerBoardOneFaceDown())
+            val pos = mockPosition()
+            val state = mockGameState(
+                drawSource = DrawSource.DECK,
+                drawnCard = mockCard(),
+                players = listOf(p1),
+                currentPlayerIndex = 0,
+                finisherPlayerId = null,
+                phase = GamePhase.AWAITING_REPLACEMENT
+            )
+            val result = engine.discardDrawnCardAndReveal(state, pos)
+
+            //Der Zweig (finalTurns <= 0) wird ausgelöst
+            assertEquals(GamePhase.ROUND_FINISHED, result.phase)
+            assertEquals("p1", result.finisherPlayerId)
+            assertEquals(0, result.finalTurnsRemaining)
+        }
+    }
+
+    @Nested
+    inner class FinishRoundTest {
+
+        @Test
+        fun `calculates scores correctly without any clearing`() {
+            // 12 Karten mit Wert 1 = 12 Punkte (Keine Spalte gleich, da Skyjo 3 pro Spalte hat)
+            // Wir nehmen Werte, die sich in der Spalte unterscheiden: 1, 2, 3, 1, 2, 3...
+            val finisherBoard = mockPlayerBoardWithValues(listOf(1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3)) // Summe = 4 * (1+2+3) = 24
+            val otherBoard = mockPlayerBoardWithValues(listOf(5, 5, 6, 5, 5, 6, 5, 5, 6, 5, 5, 6)) // Summe = 4 * (5+5+6) = 64
+            val p1 = mockPlayer("finisher", finisherBoard)
+            val p2 = mockPlayer("other", otherBoard)
+            val state = mockGameState(
+                players = listOf(p1, p2),
+                finisherPlayerId = "finisher",
+                phase = GamePhase.FINAL_TURNS
+            )
+            val result = engine.finishRound(state)
+            val finisherResult = result.roundResult!!.scores.first { it.playerId == "finisher" }
+            val otherResult = result.roundResult!!.scores.first { it.playerId == "other" }
+
+            assertEquals(24, finisherResult.rawScore)
+            assertEquals(64, otherResult.rawScore)
+        }
+
+        @Test
+        fun `doubles finisher score on a tie`() {
+            // Beide Spieler haben exakt 24 Punkte (4 Spalten à 1+2+3)
+            val values = listOf(1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3)
+            val finisherBoard = mockPlayerBoardWithValues(values)
+            val otherBoard = mockPlayerBoardWithValues(values)
+            val p1 = mockPlayer("finisher", finisherBoard)
+            val p2 = mockPlayer("other", otherBoard)
+            val state = mockGameState(
+                players = listOf(p1, p2),
+                finisherPlayerId = "finisher",
+                phase = GamePhase.FINAL_TURNS
+            )
+            val result = engine.finishRound(state)
+            val finisherResult = result.roundResult!!.scores.first { it.playerId == "finisher" }
+
+            // Raw: 24, Final: 48 (Verdoppelt wegen Gleichstand)
+            assertEquals(24, finisherResult.rawScore)
+            assertEquals(48, finisherResult.finalScore)
+        }
+
+        @Test
+        fun `doubles finisher score when another player is better`() {
+            // Finisher hat 64 Punkte (4 Spalten à 5+5+6)
+            val finisherBoard = mockPlayerBoardWithValues(listOf(5, 5, 6, 5, 5, 6, 5, 5, 6, 5, 5, 6))
+            // Andere Spieler hat nur 24 Punkte
+            val otherBoard = mockPlayerBoardWithValues(listOf(1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3))
+            val p1 = mockPlayer("finisher", finisherBoard)
+            val p2 = mockPlayer("other", otherBoard)
+            val state = mockGameState(
+                players = listOf(p1, p2),
+                finisherPlayerId = "finisher"
+            )
+            val result = engine.finishRound(state)
+            val finisherResult = result.roundResult!!.scores.first { it.playerId == "finisher" }
+
+            // Raw: 64, Final: 128
+            assertEquals(64, finisherResult.rawScore)
+            assertEquals(128, finisherResult.finalScore)
+        }
+
+        @Test
+        fun `does not double negative scores even if someone else is lower`() {
+            // Finisher hat -12 Punkte (4 Spalten à -1, 0, -2)
+            val finisherBoard = mockPlayerBoardWithValues(listOf(-1, 0, -2, -1, 0, -2, -1, 0, -2, -1, 0, -2))
+            // Jemand anderes ist noch besser: -24 Punkte
+            val otherBoard = mockPlayerBoardWithValues(listOf(-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2))
+            val p1 = mockPlayer("finisher", finisherBoard)
+            val p2 = mockPlayer("other", otherBoard)
+            val state = mockGameState(
+                players = listOf(p1, p2),
+                finisherPlayerId = "finisher"
+            )
+            val result = engine.finishRound(state)
+            val finisherResult = result.roundResult!!.scores.first { it.playerId == "finisher" }
+
+            // Bleibt bei -12, da negative Scores nicht verdoppelt werden
+            assertEquals(-12, finisherResult.rawScore)
+            assertEquals(-12, finisherResult.finalScore)
+        }
+
+        @Test
+        fun `throws InvalidMoveException if finisherPlayerId is null`() {
+            // Given
+            val state = mockGameState(
+                phase = GamePhase.FINAL_TURNS,
+                finisherPlayerId = null
+            )
+
+            // When / Then
+            val exception = assertThrows<InvalidMoveException> {
+                engine.finishRound(state) // Setze die Methode im Code ggf. auf internal
+            }
+            assertTrue(exception.message!!.contains("cannot finish round without a finisher"))
+        }
+    }
+
+    @Nested
+    inner class StartingPlayerLogic {
+
+        @Test
+        fun highestVisibleSum() {
+            // Player 0: Enthüllt (0,0) und (1,0) -> Werte 1 und 2. Summe = 3
+            val p0 = mockPlayer("p0", mockPlayerBoardWithValues(listOf(1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)))
+
+            // Player 1: Enthüllt (0,0) und (1,0) -> Werte 5 und 10. Summe = 15
+            val p1 = mockPlayer("p1", mockPlayerBoardWithValues(listOf(5, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)))
+
+            val initialReveals = mapOf(
+                "p0" to setOf(mockPosition(0, 0), mockPosition(1, 0)),
+                "p1" to setOf(mockPosition(0, 0), mockPosition(1, 0))
+            )
+            val startIndex = engine.determineStartingPlayerIndex(listOf(p0, p1), initialReveals)
+
+            // Player 1 (Index 1) hat 15, Player 0 nur 3.
+            assertEquals(1, startIndex)
+        }
+
+        @Test
+        fun firstPlayerWhenTie() {
+            // Beide haben die gleiche Summe (3)
+            val p0 = mockPlayer("p0", mockPlayerBoardWithValues(listOf(1, 2, 10, 10)))
+            val p1 = mockPlayer("p1", mockPlayerBoardWithValues(listOf(1, 2, 5, 5)))
+
+            val initialReveals = mapOf(
+                "p0" to setOf(mockPosition(0, 0), mockPosition(1, 0)),
+                "p1" to setOf(mockPosition(0, 0), mockPosition(1, 0))
+            )
+
+            val startIndex = engine.determineStartingPlayerIndex(listOf(p0, p1), initialReveals)
+
+            // maxByOrNull gibt bei Gleichstand das erste Element zurück
+            assertEquals(0, startIndex)
+        }
+
+        @Test
+        fun negativeValues() {
+            // Wir definieren zwei feste Positionen für den Reveal
+            val pos1 = mockPosition(col = 0, row = 0)
+            val pos2 = mockPosition(col = 1, row = 0)
+            val revealSet = setOf(pos1, pos2)
+
+            // Player 0: Summe soll -5 sein (-3 + -2)
+            val p0 = mockPlayer("p0", mockPlayerBoardWithExplicitValues(mapOf(
+                pos1 to -3,
+                pos2 to -2
+            )))
+
+            // Player 1: Summe soll -2 sein (0 + -2)
+            val p1 = mockPlayer("p1", mockPlayerBoardWithExplicitValues(mapOf(
+                pos1 to 0,
+                pos2 to -2
+            )))
+
+            val initialReveals = mapOf("p0" to revealSet, "p1" to revealSet)
+            val startIndex = engine.determineStartingPlayerIndex(listOf(p0, p1), initialReveals)
+
+            // Player 1 (Index 1) muss anfangen, da -2 größer ist als -5
+            assertEquals(1, startIndex, "Player 1 should start because -2 > -5")
+        }
+
+        @Test
+        fun emptyPlayerList() {
+            // Dieser Test deckt das ?: 0 am Ende ab
+            val startIndex = engine.determineStartingPlayerIndex(emptyList(), emptyMap())
+            assertEquals(0, startIndex)
+        }
+    }
+
+    //Hilfsfunktionen (Mocking)
+    private fun mockPosition(col: Int = 0, row: Int = 0) = BoardPosition(col, row)
+    private fun mockCard(id: Int = 1, value: Int = 1) = SkyjoCard(id, value)
+    private fun mockPlayer(id: String = "p1", board: PlayerBoard = mockPlayerBoard()) = PlayerState(id, board)
+    private fun mockPlayerBoard(defaultValue: Int = 0, faceUp: Boolean = false): PlayerBoard {
+        val slots = BoardLayout.POSITIONS.associateWith{pos ->
+            val uniqueId = pos.row * BoardLayout.COLUMNS + pos.column
+            BoardSlot.Occupied(SkyjoCard(id = uniqueId, defaultValue), faceUp)
+        }
+        return PlayerBoard(slots)
+    }
+    private fun mockPlayerBoardWithValues(values: List<Int>): PlayerBoard {
+        // Falls die Liste zu kurz ist, füllen wir mit hohen Werten auf
+        val cardValues = values + List(12) { it + 100 }
+
+        val slots = BoardLayout.POSITIONS.mapIndexed { index, pos ->
+            val uniqueId = pos.row * BoardLayout.COLUMNS + pos.column
+            pos to BoardSlot.Occupied(SkyjoCard(id = uniqueId, value = cardValues[index]), faceUp = true)
+        }.toMap()
+        return PlayerBoard(slots)
+    }
+    private fun mockPlayerBoardWithExplicitValues(positionValues: Map<BoardPosition, Int>): PlayerBoard {
+        val slots = BoardLayout.POSITIONS.associateWith { pos ->
+            val value = positionValues[pos] ?: 0 // Nimm den definierten Wert oder 0
+            val uniqueId = pos.row * BoardLayout.COLUMNS + pos.column
+            BoardSlot.Occupied(SkyjoCard(id = uniqueId, value = value), faceUp = true)
+        }
+        return PlayerBoard(slots)
+    }
+    private fun mockPlayerBoardMissingColumn(faceUp: Boolean = false): PlayerBoard {
+        val slots = BoardLayout.POSITIONS.associateWith{pos ->
+            val uniqueId = pos.row * BoardLayout.COLUMNS + pos.column
+            val uniqueVal = pos.row + pos.column
+            val clear = pos.column == 0
+            if (clear) {
+                BoardSlot.Cleared
+            }else {
+                BoardSlot.Occupied(SkyjoCard(id = uniqueId, uniqueVal), faceUp)
+            }
+        }
+        return PlayerBoard(slots)
+    }
+    private fun mockPlayerBoardOneFaceDown(faceUp: Boolean = true): PlayerBoard {
+        val slots = BoardLayout.POSITIONS.associateWith{pos ->
+            val uniqueId = pos.row * BoardLayout.COLUMNS + pos.column
+            val uniqueVal = pos.row + pos.column
+            val close = pos.column == 0 && pos.row == 0
+            if (close) {
+                BoardSlot.Occupied(SkyjoCard(id = uniqueId, uniqueVal), faceUp = false)
+            }else {
+                BoardSlot.Occupied(SkyjoCard(id = uniqueId, uniqueVal), faceUp)
+            }
+        }
+        return PlayerBoard(slots)
+    }
+    private fun mockGameState(
+        players: List<PlayerState> = listOf(mockPlayer("p1"), mockPlayer("p2")),
+        currentPlayerIndex: Int = 0,
+        phase: GamePhase = GamePhase.NOT_STARTED,
+        drawPile: DrawPile = DrawPile.empty(),
+        discardPile: DiscardPile = DiscardPile.empty(),
+        drawnCard: SkyjoCard? = null,
+        drawSource: DrawSource? = null,
+        finisherPlayerId: String? = null,
+        finalTurnsRemaining: Int = 0,
+        roundResult: RoundResult? = null,
+        shuffleSeed: Long? = 123L,
+        shuffleCount: Int = 0
+    )= GameState(
+        players = players,
+        currentPlayerIndex = currentPlayerIndex,
+        drawPile = drawPile,
+        discardPile = discardPile,
+        phase = phase,
+        drawnCard = drawnCard,
+        drawSource = drawSource,
+        finisherPlayerId = finisherPlayerId,
+        finalTurnsRemaining = finalTurnsRemaining,
+        roundResult = roundResult,
+        shuffleSeed = shuffleSeed,
+        shuffleCount = shuffleCount
+    )
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,4 +20,4 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "skyjo-frontend"
-include(":app")
+include(":app", ":game")


### PR DESCRIPTION
Die Spiellogik war bisher nur im Backend-Repo. Das macht keinen Sinn weil die Android-App so nicht eigenständig kompiliert werden kann und man immer beide Repos braucht.

Deswegen hab ich die komplette Spiellogik (Domain Model + SkyjoEngine + alle Tests) aus dem Backend-Branch `5-feat-skyjo-spiellogik-kernkomponenten` hierher übertragen. Ursprünglich geschrieben von amenity283 (Model & Engine) und Amelie (Tests).

Das ganze ist jetzt ein Multi-Modul-Projekt:
- `:app` – Android App wie bisher
- `:game` – reines Kotlin-JVM-Modul mit der ganzen Spiellogik

Die App hängt einfach mit `implementation(project(":game"))` davon ab.

Das `:game`-Modul ist bewusst kein Android-Modul, weil die Spiellogik keine Android-Abhängigkeiten braucht. Vorteil: JUnit 5 läuft direkt ohne Umwege, kein Robolectric nötig.

**Was drin ist:**
- alle Modelle (SkyjoCard, BoardPosition, BoardLayout, PlayerBoard, GameState, DrawPile, DiscardPile usw.)
- SkyjoEngine (ohne @Component, das war Spring-spezifisch)
- alle Fehlerklassen
- alle Tests (106 Testfälle aus dem Backend übernommen)

**CI:** läuft jetzt in zwei Schritten – erst `:game:test` dann `testDebugUnitTest`. Coverage wird für beide Module generiert und SonarCloud scannt beide automatisch.

Das Backend behält seine eigene Kopie der Logik weil der Server sie für die serverseitige Verarbeitung braucht.