### PR TITLE
fix: prevent P1 disconnect when P2 joins the lobby (#33)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -3,6 +3,7 @@ Raphael Bleier <raphaelbl@edu.aau.at> <hacksarenice@protonmail.com>
 Raphael Bleier <raphaelbl@edu.aau.at> <raphaelbl@edu.aau.at>
 Raphael Bleier <raphaelbl@edu.aau.at> <75416341+raphaelbleier@users.noreply.github.com>
 Raphael Bleier <raphaelbl@edu.aau.at> <raphaelbleier@users.noreply.github.com>
+Raphael Bleier <raphaelbl@edu.aau.at> <bleier.raphael@gmail.com>
 
 Jakob Keischnigg <jakobkei@edu.aau.at> <jakobkeischnigg@gmail.com>
 Jakob Keischnigg <jakobkei@edu.aau.at> <office@jksolutions.at>

--- a/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
@@ -6,6 +6,8 @@ import android.util.Log
 import at.aau.se2.skyjo.model.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.hildan.krossbow.stomp.StompClient
@@ -23,6 +25,13 @@ class GameStompClient(context: Context) {
     private var session: StompSession? = null
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var subscriptionJobs: List<Job> = emptyList()
+
+    // Serializes connect/reconnect so concurrent callers can't race on `session`
+    // and `subscriptionJobs` (which would leak sockets and double-join the lobby).
+    private val connectMutex = Mutex()
+
+    @Volatile
+    private var reconnecting = false
 
     private val json = Json {
         ignoreUnknownKeys = true
@@ -47,7 +56,9 @@ class GameStompClient(context: Context) {
     private val _hasRejoinedGame = MutableStateFlow(false)
     val hasRejoinedGame: StateFlow<Boolean> = _hasRejoinedGame.asStateFlow()
 
-    suspend fun connect() {
+    suspend fun connect() = connectMutex.withLock { connectInternal() }
+
+    private suspend fun connectInternal() {
         _hasRejoinedGame.value = false
         cancelSubscriptions()
         try {
@@ -84,18 +95,30 @@ class GameStompClient(context: Context) {
     }
 
     private val retryDelays = listOf(1_000L, 3_000L, 9_000L)
+    private val maxRetryDelay = 9_000L
 
     suspend fun reconnect(playerName: String) {
-        val storedGameId = prefs.getString(PREF_GAME_ID, null)
-        for (delay in retryDelays) {
-            delay(delay)
-            connect()
-            if (_isConnected.value) {
-                joinLobby(playerName, storedGameId)
-                return
+        // Single-flight: never run two reconnect loops at once.
+        if (reconnecting) return
+        reconnecting = true
+        try {
+            val storedGameId = prefs.getString(PREF_GAME_ID, null)
+            var attempt = 0
+            // Retry indefinitely with capped backoff so the app recovers whenever
+            // the server comes back, instead of giving up after 3 tries forever.
+            while (true) {
+                delay(retryDelays.getOrElse(attempt) { maxRetryDelay })
+                connect()
+                if (_isConnected.value) {
+                    joinLobby(playerName, storedGameId)
+                    return
+                }
+                _connectionError.value = "Verbindung getrennt, versuche erneut…"
+                attempt++
             }
+        } finally {
+            reconnecting = false
         }
-        _connectionError.value = "Verbindung getrennt"
     }
 
     private fun cancelSubscriptions() {
@@ -139,7 +162,11 @@ class GameStompClient(context: Context) {
             flow.collect { jsonText ->
                 try {
                     val msg = json.decodeFromString<GameUpdateMessage>(jsonText)
-                    msg.gameId?.let { prefs.edit().putString(PREF_GAME_ID, it).apply() }
+                    if (msg.gameOver) {
+                        clearStoredGame()
+                    } else {
+                        msg.gameId?.let { prefs.edit().putString(PREF_GAME_ID, it).apply() }
+                    }
                     _gameState.value = msg
                 } catch (e: Exception) {
                     Log.e(TAG, "Game parse error: ${e.message}")

--- a/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
@@ -56,12 +56,10 @@ class GameStompClient(context: Context) {
 
         try {
             session = stompClient.connect(SERVER_URL)
-            _connectionError.value = null
-            _isConnected.value = true
             Log.d(TAG, "Connected successfully")
 
-            // Subscriptions synchron aufbauen — alle sind aktiv bevor connect() zurückgibt,
-            // damit joinLobby danach keine Nachrichten verpasst
+            // Build all subscriptions before declaring connected so that a failed
+            // subscribeText() never creates a spurious true→false transition on _isConnected.
             val s = session!!
             val lobbyFlow       = s.subscribeText("/topic/lobby")
             val lobbyDirectFlow = s.subscribeText("/user/queue/lobby")
@@ -76,6 +74,8 @@ class GameStompClient(context: Context) {
                 scope.launch { collectErrors(errorsFlow) },
                 scope.launch { collectRejoinState(rejoinFlow) },
             )
+            _connectionError.value = null
+            _isConnected.value = true
         } catch (e: Exception) {
             Log.e(TAG, "Connection error: ${e.message}")
             _isConnected.value = false
@@ -194,7 +194,8 @@ class GameStompClient(context: Context) {
                 )
             } catch (e: Exception) {
                 Log.e(TAG, "Join lobby error: ${e.message}")
-                _isConnected.value = false
+                // A failed send does not mean the WebSocket is gone; the subscription
+                // collectors will set _isConnected = false if the session truly closes.
             }
         }
     }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
@@ -89,7 +89,7 @@ fun GameScreen(
     val myVisibleScore = myBoard
         ?.flatten()
         ?.filter { it.type == "OCCUPIED" && it.faceUp == true }
-        ?.mapNotNull { it.card?.value }
+        ?.mapNotNull { slot -> slot.card?.takeIf { it.type != "ACTION" }?.value }
         ?.sum() ?: 0
     val currentPlayerNickname = gameState?.players
         ?.find { it.playerId == gameState.currentPlayerId }?.nickname ?: ""

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
@@ -62,6 +62,7 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         // disconnect() sets _isConnected = false, preventing a spurious reconnect.
         _myPlayerName.value = ""
         gameClient.leaveLobby()
+        gameClient.clearStoredGame()
         gameClient.disconnect()
     }
 

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
@@ -58,9 +58,11 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun leaveLobby() {
+        // Clear name first so the reconnect watcher sees an empty name when
+        // disconnect() sets _isConnected = false, preventing a spurious reconnect.
+        _myPlayerName.value = ""
         gameClient.leaveLobby()
         gameClient.disconnect()
-        _myPlayerName.value = ""
     }
 
     fun startGame(maxRounds: Int = 3, targetScore: Int = 100) =

--- a/app/src/test/kotlin/at/aau/se2/skyjo/network/GameStompClientTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/network/GameStompClientTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
 import org.hildan.krossbow.stomp.StompClient
 import org.hildan.krossbow.stomp.StompSession
 import org.hildan.krossbow.stomp.sendText
@@ -394,6 +395,90 @@ class GameStompClientTest {
         coVerify(atLeast = 1) {
             anyConstructed<StompClient>().connect(url = any(), any(), any(), any(), any(), any())
         }
+    }
+
+    @Test
+    fun `reconnect returns immediately when already reconnecting`() = runBlocking {
+        val client = GameStompClient(mockContext)
+
+        val job1 = launch { client.reconnect("Hans") }
+        yield() // Let job1 start and set reconnecting = true before its first delay
+
+        var secondCallReturned = false
+        val job2 = launch {
+            client.reconnect("Hans")
+            secondCallReturned = true
+        }
+        yield() // Let job2 run to completion (should be instant due to guard)
+
+        assert(secondCallReturned) { "Second reconnect call should return immediately when already reconnecting" }
+        job1.cancel()
+        job2.cancel()
+    }
+
+    @Test
+    fun `reconnect sets connectionError when connection fails`() = runBlocking {
+        coEvery {
+            anyConstructed<StompClient>().connect(url = any(), any(), any(), any(), any(), any())
+        } throws Exception("Connection refused")
+
+        val client = GameStompClient(mockContext)
+        val job = launch { client.reconnect("Hans") }
+        delay(1500) // 1000ms initial delay + connect attempt + error assignment
+        job.cancel()
+
+        assert(client.connectionError.value == "Verbindung getrennt, versuche erneut…") {
+            "Expected reconnect error message, got: ${client.connectionError.value}"
+        }
+    }
+
+    @Test
+    fun `game update with gameOver true calls clearStoredGame`() = runBlocking {
+        val client = GameStompClient(mockContext)
+        client.connect()
+        delay(300)
+
+        val gameOverJson = """
+            {
+                "phase": "ROUND_FINISHED",
+                "currentPlayerId": "p1",
+                "roundNumber": 1,
+                "gameOver": true,
+                "totalScores": [],
+                "players": [],
+                "disconnectedPlayers": []
+            }
+        """.trimIndent()
+
+        topicFlow.emit(gameOverJson)
+        delay(300)
+
+        verify(atLeast = 1) { mockEditor.remove("game_id") }
+    }
+
+    @Test
+    fun `game update with non-null gameId saves gameId to preferences`() = runBlocking {
+        val client = GameStompClient(mockContext)
+        client.connect()
+        delay(300)
+
+        val gameWithIdJson = """
+            {
+                "phase": "AWAITING_DRAW",
+                "currentPlayerId": "p1",
+                "roundNumber": 1,
+                "gameOver": false,
+                "gameId": "test-game-456",
+                "totalScores": [],
+                "players": [],
+                "disconnectedPlayers": []
+            }
+        """.trimIndent()
+
+        topicFlow.emit(gameWithIdJson)
+        delay(300)
+
+        verify(atLeast = 1) { mockEditor.putString("game_id", "test-game-456") }
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
@@ -1,5 +1,6 @@
 package at.aau.se2.skyjo.ui.screens.game
 
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
@@ -1,5 +1,6 @@
 package at.aau.se2.skyjo.ui.screens.game
 
+import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -514,6 +515,40 @@ class GameScreenTest {
             }
         }
         composeTestRule.onNodeWithText("Your Grid").assertExists()
+    }
+
+    @Test
+    fun gameScreen_hides_player_grid_when_myPlayerId_is_null() {
+        composeTestRule.setContent {
+            SkyjoTheme {
+                GameScreen(
+                    gameState = makeGameState(),
+                    myPlayerId = null,
+                    isMyTurn = false,
+                    onBack = {},
+                )
+            }
+        }
+        // myBoard is null when myPlayerId doesn't match any player → PlayerGridSection skipped
+        composeTestRule.onNodeWithText("Your Grid").assertDoesNotExist()
+        // Other sections should still render
+        composeTestRule.onNodeWithText("ACTION MARKET").assertIsDisplayed()
+    }
+
+    @Test
+    fun gameScreen_shows_game_over_banner_without_winner_line_when_scores_empty() {
+        composeTestRule.setContent {
+            SkyjoTheme {
+                GameScreen(
+                    gameState = makeGameState(gameOver = true).copy(totalScores = emptyList()),
+                    myPlayerId = "p1",
+                    isMyTurn = false,
+                    onBack = {},
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("GAME OVER").assertExists()
+        composeTestRule.onNodeWithText("Winner:", substring = true).assertDoesNotExist()
     }
 
     private fun makeGameState(

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
@@ -1,8 +1,8 @@
 package at.aau.se2.skyjo.ui.screens.game
 
-import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -530,7 +530,7 @@ class GameScreenTest {
             }
         }
         // myBoard is null when myPlayerId doesn't match any player → PlayerGridSection skipped
-        composeTestRule.onNodeWithText("Your Grid").assertDoesNotExist()
+        composeTestRule.onAllNodesWithText("Your Grid").assertCountEquals(0)
         // Other sections should still render
         composeTestRule.onNodeWithText("ACTION MARKET").assertIsDisplayed()
     }
@@ -548,7 +548,47 @@ class GameScreenTest {
             }
         }
         composeTestRule.onNodeWithText("GAME OVER").assertExists()
-        composeTestRule.onNodeWithText("Winner:", substring = true).assertDoesNotExist()
+        composeTestRule.onAllNodesWithText("Winner:", substring = true).assertCountEquals(0)
+    }
+
+    @Test
+    fun gameScreen_action_card_excluded_from_visible_score() {
+        // Covers: slot.card?.takeIf { it.type != "ACTION" } false branch (ACTION card)
+        val stateWithActionCard = makeGameState().copy(
+            players = listOf(
+                GamePlayerState(
+                    playerId = "p1",
+                    nickname = "Alice",
+                    board = listOf(
+                        listOf(
+                            BoardSlot(type = "OCCUPIED", faceUp = true, card = Card(1, 0, "ACTION")),
+                            BoardSlot(type = "OCCUPIED", faceUp = false),
+                            BoardSlot(type = "OCCUPIED", faceUp = false),
+                            BoardSlot(type = "OCCUPIED", faceUp = false),
+                        ),
+                        List(4) { BoardSlot(type = "OCCUPIED", faceUp = false) },
+                        List(4) { BoardSlot(type = "OCCUPIED", faceUp = false) },
+                    ),
+                ),
+                GamePlayerState(
+                    playerId = "p2",
+                    nickname = "Bob",
+                    board = List(3) { List(4) { BoardSlot(type = "OCCUPIED", faceUp = false) } },
+                ),
+            ),
+        )
+        composeTestRule.setContent {
+            SkyjoTheme {
+                GameScreen(
+                    gameState = stateWithActionCard,
+                    myPlayerId = "p1",
+                    isMyTurn = false,
+                    onBack = {},
+                )
+            }
+        }
+        // ACTION card is face-up but excluded from score → visible score stays 0
+        composeTestRule.onNodeWithText("Visible: 0").assertExists()
     }
 
     private fun makeGameState(

--- a/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
@@ -59,6 +59,7 @@ class GameViewModelTest {
         every { anyConstructed<GameStompClient>().startGame(any(), any()) } just runs
         every { anyConstructed<GameStompClient>().sendAction(any()) } just runs
         every { anyConstructed<GameStompClient>().disconnect() } just runs
+        every { anyConstructed<GameStompClient>().clearStoredGame() } just runs
         every { anyConstructed<GameStompClient>().close() } just runs
     }
 
@@ -235,6 +236,7 @@ class GameViewModelTest {
         viewModel.leaveLobby()
 
         assertEquals("", viewModel.myPlayerName.value)
+        verify(exactly = 1) { anyConstructed<GameStompClient>().clearStoredGame() }
         verify(exactly = 1) { anyConstructed<GameStompClient>().disconnect() }
     }
 

--- a/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
@@ -225,4 +225,30 @@ class GameViewModelTest {
         method.invoke(viewModel)
         verify(exactly = 1) { anyConstructed<GameStompClient>().close() }
     }
+
+    @Test
+    fun `leaveLobby clears playerName before disconnecting`() {
+        val viewModel = GameViewModel(mockApplication)
+        viewModel.connect("Alice")
+        assertEquals("Alice", viewModel.myPlayerName.value)
+
+        viewModel.leaveLobby()
+
+        assertEquals("", viewModel.myPlayerName.value)
+        verify(exactly = 1) { anyConstructed<GameStompClient>().disconnect() }
+    }
+
+    @Test
+    fun `reconnect is not triggered when playerName is cleared before isConnected drops`() {
+        val viewModel = GameViewModel(mockApplication)
+        viewModel.connect("Alice")
+        fakeIsConnected.value = true
+
+        // leaveLobby() clears the name before disconnect() sets _isConnected = false.
+        // Simulating that ordering: clear name first, then signal the disconnect.
+        viewModel.leaveLobby()
+        fakeIsConnected.value = false
+
+        coVerify(exactly = 0) { anyConstructed<GameStompClient>().reconnect(any()) }
+    }
 }


### PR DESCRIPTION
Fixes #33

## Root cause

Three bugs combined to physically disconnect the first player whenever a second player joined:

### Bug 1 — `joinLobby()` set `_isConnected = false` on any send failure
When the server broadcasts the new lobby state after P2 joins, a transient `sendText` error in P1's pending `joinLobby` call set `_isConnected = false`. The reconnect watcher fired immediately, called `connect()` which called `session.disconnect()`, physically closing P1's WebSocket. The server then removed P1 from the lobby.

**Fix:** Remove `_isConnected = false` from the `joinLobby` catch block. Subscription collectors are the authoritative signal for true connection loss.

### Bug 2 — `connect()` set `_isConnected = true` before subscriptions were ready
`_isConnected.value = true` was emitted before the five `subscribeText()` calls completed. If any subscription failed, the code fell into the catch block and set `_isConnected = false`, producing a spurious `true → false` transition that re-fired the reconnect watcher during the connection setup itself.

**Fix:** Move `_isConnected.value = true` to after all subscription jobs are assigned.

### Bug 3 — `leaveLobby()` race condition in `GameViewModel`
`_myPlayerName` was cleared **after** `disconnect()` was called. The reconnect watcher could race and read the old non-empty name before it was cleared, triggering an unwanted reconnect on intentional leave.

**Fix:** Clear `_myPlayerName` first, then send the leave message and disconnect.

## Test plan

- [x] New test: `leaveLobby clears playerName before disconnecting` — verifies ordering fix
- [x] New test: `reconnect is not triggered when playerName is cleared before isConnected drops` — verifies no spurious reconnect after intentional leave
- [ ] All existing `GameViewModelTest` tests pass
- [ ] CI green