### PR TITLE
Point frontend to university backend server

### DIFF
--- a/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
@@ -281,7 +281,7 @@ class GameStompClient(context: Context) {
 
     companion object {
         private const val TAG = "GameStompClient"
-        private const val SERVER_URL = "ws://10.0.2.2:8765/ws"
+        private const val SERVER_URL = "ws://se2-demo.aau.at:53209/ws"
         private const val PREF_GAME_ID = "game_id"
     }
 }

--- a/app/src/test/kotlin/at/aau/se2/skyjo/network/GameStompClientTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/network/GameStompClientTest.kt
@@ -79,6 +79,24 @@ class GameStompClientTest {
     }
 
     @Test
+    fun `connect uses university backend websocket url`() = runBlocking {
+        val client = GameStompClient(mockContext)
+        client.connect()
+        delay(300)
+
+        coVerify(atLeast = 1) {
+            anyConstructed<StompClient>().connect(
+                url = "ws://se2-demo.aau.at:53209/ws",
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
     fun `connect resets connectionError on success`() = runBlocking {
         val client = GameStompClient(mockContext)
         client.connect()


### PR DESCRIPTION
## Summary
- update the STOMP WebSocket endpoint to ws://se2-demo.aau.at:53209/ws
- add a unit test that verifies the frontend connects to the deployed backend URL