### PR TITLE
feat: player grid carousel and action card name labels

### DIFF
--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/components/SkyjoScaffold.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/components/SkyjoScaffold.kt
@@ -72,7 +72,7 @@ fun SkyjoTopBar(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 8.dp)
-                .height(56.dp),
+                .height(80.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             IconButton(onClick = onMenuClick) {

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
@@ -124,6 +124,11 @@ fun GameScreen(
     var pendingEnlightenmentCardIndex by remember(isMyTurn, gameState?.roundNumber) {
         mutableStateOf<Int?>(null)
     }
+    var viewedPlayerIndex by remember(isMyTurn, gameState?.roundNumber) {
+        mutableStateOf(
+            gameState?.players?.indexOfFirst { it.playerId == myPlayerId }?.coerceAtLeast(0) ?: 0
+        )
+    }
 
     val currentPhase = gameState?.phase
     val myPlayer = gameState?.players?.find { it.playerId == myPlayerId }
@@ -174,6 +179,8 @@ fun GameScreen(
                     pendingAction = pendingAction,
                     swapState = swapState,
                     pendingEnlightenmentCardIndex = pendingEnlightenmentCardIndex,
+                    viewedPlayerIndex = viewedPlayerIndex,
+                    onViewedPlayerIndexChange = { viewedPlayerIndex = it },
                     onPendingActionChange = { pendingAction = it },
                     onSwapStateChange = { swapState = it },
                     onPendingEnlightenmentCardIndexChange = { pendingEnlightenmentCardIndex = it },
@@ -324,6 +331,8 @@ private fun GameContent(
     pendingAction: String?,
     swapState: SwapSelectionState?,
     pendingEnlightenmentCardIndex: Int?,
+    viewedPlayerIndex: Int,
+    onViewedPlayerIndexChange: (Int) -> Unit,
     onPendingActionChange: (String?) -> Unit,
     onSwapStateChange: (SwapSelectionState?) -> Unit,
     onPendingEnlightenmentCardIndexChange: (Int?) -> Unit,
@@ -369,96 +378,54 @@ private fun GameContent(
         DrawnCardSection(card = drawnCard)
     }
 
-    if (myBoard != null) {
-        PlayerGridSection(
-            myBoard = myBoard,
-            myVisibleScore = myVisibleScore,
-            isMyTurn = isMyTurn,
-            isReplacementPhase = isReplacementPhase,
-            pendingAction = pendingAction,
-            swapState = swapState,
-            myPlayerId = myPlayerId ?: "",
-            onPendingActionChange = onPendingActionChange,
-            onReplaceCard = onReplaceCard,
-            onDiscardAndReveal = onDiscardAndReveal,
-            onSwapSlotSelected = { row, col ->
-                if (myPlayerId != null) {
-                    when (val state = swapState) {
-                        is SwapSelectionState.AwaitingFirst -> {
-                            onSwapStateChange(
-                                SwapSelectionState.AwaitingSecond(
-                                    cardIndex = state.cardIndex,
-                                    player1Id = myPlayerId,
-                                    player1Row = row,
-                                    player1Col = col,
-                                    ownCardsOnly = state.ownCardsOnly,
-                                ),
-                            )
-                        }
-                        is SwapSelectionState.AwaitingSecond -> {
-                            if (state.ownCardsOnly && state.player1Id == myPlayerId) {
-                                val selectedSameSlot = row == state.player1Row && col == state.player1Col
-                                if (!selectedSameSlot) {
-                                    onPlaySwapOwnCards(
-                                        state.cardIndex,
-                                        state.player1Row,
-                                        state.player1Col,
-                                        row,
-                                        col,
-                                    )
-                                    onSwapStateChange(null)
-                                }
-                            } else if (!state.ownCardsOnly && myPlayerId != state.player1Id) {
-                                onPlayPlayerSwapCard(
+    PlayerGridCarousel(
+        players = gameState.players,
+        myPlayerId = myPlayerId ?: "",
+        myBoard = myBoard ?: emptyList(),
+        myVisibleScore = myVisibleScore,
+        isMyTurn = isMyTurn,
+        isReplacementPhase = isReplacementPhase,
+        pendingAction = pendingAction,
+        swapState = swapState,
+        viewedPlayerIndex = viewedPlayerIndex,
+        onViewedPlayerIndexChange = onViewedPlayerIndexChange,
+        onPendingActionChange = onPendingActionChange,
+        onReplaceCard = onReplaceCard,
+        onDiscardAndReveal = onDiscardAndReveal,
+        onSwapSlotSelected = { row, col ->
+            if (myPlayerId != null) {
+                when (val state = swapState) {
+                    is SwapSelectionState.AwaitingFirst -> {
+                        onSwapStateChange(
+                            SwapSelectionState.AwaitingSecond(
+                                cardIndex = state.cardIndex,
+                                player1Id = myPlayerId,
+                                player1Row = row,
+                                player1Col = col,
+                                ownCardsOnly = state.ownCardsOnly,
+                            ),
+                        )
+                    }
+                    is SwapSelectionState.AwaitingSecond -> {
+                        if (state.ownCardsOnly && state.player1Id == myPlayerId) {
+                            val selectedSameSlot = row == state.player1Row && col == state.player1Col
+                            if (!selectedSameSlot) {
+                                onPlaySwapOwnCards(
                                     state.cardIndex,
-                                    state.player1Id,
                                     state.player1Row,
                                     state.player1Col,
-                                    myPlayerId,
                                     row,
                                     col,
                                 )
                                 onSwapStateChange(null)
                             }
-                        }
-                        null -> Unit
-                    }
-                }
-            },
-        )
-    }
-
-    val others = gameState.players.filter { it.playerId != myPlayerId }
-    if (others.isNotEmpty()) {
-        OtherPlayersSection(
-            players = others,
-            totalScores = gameState.totalScores,
-            currentPlayerId = gameState.currentPlayerId,
-            disconnectedPlayers = gameState.disconnectedPlayers,
-            swapState = swapState,
-            onSlotSelected = { playerId, row, col ->
-                when (val state = swapState) {
-                    is SwapSelectionState.AwaitingFirst -> {
-                        if (!state.ownCardsOnly) {
-                            onSwapStateChange(
-                                SwapSelectionState.AwaitingSecond(
-                                    cardIndex = state.cardIndex,
-                                    player1Id = playerId,
-                                    player1Row = row,
-                                    player1Col = col,
-                                    ownCardsOnly = false,
-                                ),
-                            )
-                        }
-                    }
-                    is SwapSelectionState.AwaitingSecond -> {
-                        if (!state.ownCardsOnly && playerId != state.player1Id) {
+                        } else if (!state.ownCardsOnly && myPlayerId != state.player1Id) {
                             onPlayPlayerSwapCard(
                                 state.cardIndex,
                                 state.player1Id,
                                 state.player1Row,
                                 state.player1Col,
-                                playerId,
+                                myPlayerId,
                                 row,
                                 col,
                             )
@@ -467,9 +434,41 @@ private fun GameContent(
                     }
                     null -> Unit
                 }
-            },
-        )
-    }
+            }
+        },
+        onOtherSlotSelected = { playerId, row, col ->
+            when (val state = swapState) {
+                is SwapSelectionState.AwaitingFirst -> {
+                    if (!state.ownCardsOnly) {
+                        onSwapStateChange(
+                            SwapSelectionState.AwaitingSecond(
+                                cardIndex = state.cardIndex,
+                                player1Id = playerId,
+                                player1Row = row,
+                                player1Col = col,
+                                ownCardsOnly = false,
+                            ),
+                        )
+                    }
+                }
+                is SwapSelectionState.AwaitingSecond -> {
+                    if (!state.ownCardsOnly && playerId != state.player1Id) {
+                        onPlayPlayerSwapCard(
+                            state.cardIndex,
+                            state.player1Id,
+                            state.player1Row,
+                            state.player1Col,
+                            playerId,
+                            row,
+                            col,
+                        )
+                        onSwapStateChange(null)
+                    }
+                }
+                null -> Unit
+            }
+        },
+    )
 
     HandActionCardsSection(
         cards = myActionCards,
@@ -575,79 +574,6 @@ private fun DrawPileRow(
             },
             modifier = Modifier.weight(1f),
         )
-    }
-}
-
-@Composable
-private fun PlayerGridSection(
-    myBoard: List<List<BoardSlot>>,
-    myVisibleScore: Int,
-    isMyTurn: Boolean,
-    isReplacementPhase: Boolean,
-    pendingAction: String?,
-    swapState: SwapSelectionState?,
-    myPlayerId: String,
-    onPendingActionChange: (String?) -> Unit,
-    onReplaceCard: (row: Int, col: Int) -> Unit,
-    onDiscardAndReveal: (row: Int, col: Int) -> Unit,
-    onSwapSlotSelected: (row: Int, col: Int) -> Unit,
-) {
-    val canSelectForSwap = when (val state = swapState) {
-        is SwapSelectionState.AwaitingFirst -> myPlayerId.isNotBlank()
-        is SwapSelectionState.AwaitingSecond -> myPlayerId.isNotBlank() &&
-                (state.ownCardsOnly || state.player1Id != myPlayerId)
-        null -> false
-    }
-
-    SectionCard(
-        title = "Your Grid",
-        badge = "Visible: $myVisibleScore",
-    ) {
-        CardGrid(
-            board = myBoard,
-            selectable = canSelectForSwap || (isMyTurn && isReplacementPhase && pendingAction != null),
-            onCardClick = { row, col ->
-                if (canSelectForSwap) {
-                    onSwapSlotSelected(row, col)
-                } else {
-                    when (pendingAction) {
-                        "REPLACE" -> {
-                            onReplaceCard(row, col)
-                            onPendingActionChange(null)
-                        }
-                        "DISCARD_AND_REVEAL" -> {
-                            onDiscardAndReveal(row, col)
-                            onPendingActionChange(null)
-                        }
-                    }
-                }
-            },
-        )
-    }
-}
-
-@Composable
-private fun OtherPlayersSection(
-    players: List<GamePlayerState>,
-    totalScores: List<TotalScore>,
-    currentPlayerId: String?,
-    disconnectedPlayers: List<String>,
-    swapState: SwapSelectionState?,
-    onSlotSelected: (playerId: String, row: Int, col: Int) -> Unit,
-) {
-    SectionCard(title = "Other Players") {
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            players.forEach { player ->
-                OtherPlayerRow(
-                    player = player,
-                    totalScore = totalScores.find { it.playerId == player.playerId }?.totalScore ?: 0,
-                    isCurrentPlayer = player.playerId == currentPlayerId,
-                    isDisconnected = player.nickname in disconnectedPlayers,
-                    swapState = swapState,
-                    onSlotSelected = { row, col -> onSlotSelected(player.playerId, row, col) },
-                )
-            }
-        }
     }
 }
 

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
@@ -1649,7 +1649,7 @@ private fun HandActionCardItem(
                     color = PrimaryGreen,
                     fontWeight = FontWeight.SemiBold,
                     textAlign = TextAlign.Center,
-                    modifier = Modifier.padding(horizontal = 4.dp, bottom = 4.dp),
+                    modifier = Modifier.padding(start = 4.dp, end = 4.dp, bottom = 4.dp),
                 )
             }
         }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
@@ -21,6 +21,13 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.filled.Autorenew
+import androidx.compose.material.icons.filled.FastForward
+import androidx.compose.material.icons.filled.Lightbulb
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Style
+import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -1389,10 +1396,20 @@ private fun ActionMarketSection(
                                     },
                                 ),
                         ) {
-                            ActionCardFaceContent(
-                                card = action,
-                                modifier = Modifier.padding(vertical = 10.dp),
-                            )
+                            Column(
+                                modifier = Modifier.padding(vertical = 8.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                            ) {
+                                ActionCardFaceContent(card = action)
+                                Text(
+                                    text = actionCardAccessibilityLabel(action),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = PrimaryGreen,
+                                    fontWeight = FontWeight.SemiBold,
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.padding(start = 4.dp, end = 4.dp, top = 4.dp),
+                                )
+                            }
                         }
                     }
                 }
@@ -1670,15 +1687,14 @@ private fun actionCardModifier(
     onPlayActionCard: (actionCardIndex: Int) -> Unit,
 ): Modifier {
     val clickModifier = if (canUseCards) {
-        Modifier
-            .testTag("play_action_card_$index")
-            .clickable { onPlayActionCard(index) }
+        Modifier.clickable { onPlayActionCard(index) }
     } else {
         Modifier
     }
 
     return Modifier
         .aspectRatio(0.65f)
+        .testTag("play_action_card_$index")
         .border(
             width = if (isActive) 2.dp else 1.dp,
             color = if (isActive) MintGreen else MintGreen.copy(alpha = 0.4f),
@@ -1730,14 +1746,14 @@ private fun cardColor(value: Int): Color = when {
 private fun cardDisplayValue(card: Card): String =
     if (card.type == "ACTION") "A" else card.value.toString()
 
-private fun actionCardDisplayLabel(card: ActionCard): String =
+private fun actionCardIcon(card: ActionCard): ImageVector =
     when (card.kind) {
-        "DEFENSE" -> "🛡️"
-        ACTION_CARD_KIND_PLAYER_SWAP -> "↔"
-        ACTION_CARD_KIND_DOUBLE_TURN -> "⏩"
-        ACTION_CARD_KIND_SWAP_OWN_CARDS -> "⇄"
-        ACTION_CARD_KIND_ENLIGHTENMENT -> card.label.ifBlank { "Enlightenment" }
-        else -> card.label.ifBlank { "Action" }
+        "DEFENSE" -> Icons.Default.Shield
+        ACTION_CARD_KIND_PLAYER_SWAP -> Icons.Default.SwapHoriz
+        ACTION_CARD_KIND_DOUBLE_TURN -> Icons.Default.FastForward
+        ACTION_CARD_KIND_SWAP_OWN_CARDS -> Icons.Default.Autorenew
+        ACTION_CARD_KIND_ENLIGHTENMENT -> Icons.Default.Lightbulb
+        else -> Icons.Default.Style
     }
 
 private fun actionCardAccessibilityLabel(card: ActionCard): String =
@@ -1755,17 +1771,11 @@ private fun ActionCardFaceContent(
     card: ActionCard,
     modifier: Modifier = Modifier,
 ) {
-    Text(
-        text = actionCardDisplayLabel(card),
-        style = if (card.kind == "DEFENSE" || card.kind == ACTION_CARD_KIND_PLAYER_SWAP || card.kind == ACTION_CARD_KIND_DOUBLE_TURN || card.kind == ACTION_CARD_KIND_SWAP_OWN_CARDS) {
-            MaterialTheme.typography.headlineSmall
-        } else {
-            MaterialTheme.typography.labelMedium
-        },
-        color = PrimaryGreen,
-        fontWeight = FontWeight.SemiBold,
-        textAlign = TextAlign.Center,
-        modifier = modifier,
+    Icon(
+        imageVector = actionCardIcon(card),
+        contentDescription = null,
+        tint = PrimaryGreen,
+        modifier = modifier.size(32.dp),
     )
 }
 

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
@@ -1598,10 +1598,22 @@ private fun HandActionCardItem(
                 onPlayActionCard = onPlayActionCard,
             ),
         ) {
-            Box(contentAlignment = Alignment.Center) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
                 ActionCardFaceContent(
                     card = card,
-                    modifier = Modifier.padding(4.dp),
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+                Text(
+                    text = actionCardAccessibilityLabel(card),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = PrimaryGreen,
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(horizontal = 4.dp, bottom = 4.dp),
                 )
             }
         }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.Style
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -36,6 +35,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -203,6 +203,8 @@ fun GameScreen(
                     onPlayActionCard = onPlayActionCard,
                     onPlayEnlightenmentCard = onPlayEnlightenmentCard,
                     onDiscardActionCard = onDiscardActionCard,
+                    enlightenmentResult = if (privateActionCardResult?.type == ACTION_CARD_RESULT_ENLIGHTENMENT) privateActionCardResult else null,
+                    onDismissEnlightenmentResult = onDismissActionCardResult,
                 )
             }
             Spacer(modifier = Modifier.height(8.dp))
@@ -223,12 +225,6 @@ fun GameScreen(
         }
     }
 
-    if (privateActionCardResult?.type == ACTION_CARD_RESULT_ENLIGHTENMENT) {
-        EnlightenmentResultDialog(
-            result = privateActionCardResult,
-            onDismiss = onDismissActionCardResult,
-        )
-    }
 }
 
 // ── Top-level section composables ────────────────────────────────────────────
@@ -355,6 +351,8 @@ private fun GameContent(
     onPlayActionCard: (actionCardIndex: Int) -> Unit,
     onPlayEnlightenmentCard: (PlayActionCardCommand) -> Unit,
     onDiscardActionCard: (actionCardIndex: Int) -> Unit,
+    enlightenmentResult: ActionCardResultMessage? = null,
+    onDismissEnlightenmentResult: () -> Unit = {},
 ) {
     val isDrawPhase = currentPhase == PHASE_AWAITING_DRAW
     val isReplacementPhase = currentPhase == PHASE_AWAITING_REPLACEMENT
@@ -477,6 +475,8 @@ private fun GameContent(
                 null -> Unit
             }
         },
+        peekResult = enlightenmentResult,
+        onDismissPeek = onDismissEnlightenmentResult,
     )
 
     HandActionCardsSection(
@@ -605,12 +605,28 @@ private fun PlayerGridCarousel(
     onDiscardAndReveal: (row: Int, col: Int) -> Unit,
     onSwapSlotSelected: (row: Int, col: Int) -> Unit,
     onOtherSlotSelected: (playerId: String, row: Int, col: Int) -> Unit,
+    peekResult: ActionCardResultMessage? = null,
+    onDismissPeek: () -> Unit = {},
 ) {
     if (players.isEmpty()) return
     val pageCount = players.size
     val safeIndex = viewedPlayerIndex.coerceIn(0, players.lastIndex)
     val viewedPlayer = players[safeIndex]
     val isOwnGrid = viewedPlayer.playerId == myPlayerId
+
+    LaunchedEffect(peekResult) {
+        if (peekResult != null) {
+            val targetIndex = players.indexOfFirst { it.playerId == peekResult.targetPlayerId }
+            if (targetIndex >= 0) onViewedPlayerIndexChange(targetIndex)
+        }
+    }
+
+    val peekedSlots: Map<Pair<Int, Int>, Int?> =
+        if (peekResult != null && viewedPlayer.playerId == peekResult.targetPlayerId) {
+            peekResult.toPeekedSlots()
+        } else {
+            emptyMap()
+        }
 
     val canSelectOwnForSwap = when (val state = swapState) {
         is SwapSelectionState.AwaitingFirst -> myPlayerId.isNotBlank()
@@ -619,10 +635,13 @@ private fun PlayerGridCarousel(
         null -> false
     }
 
+    val viewedPlayerHasDefense = !isOwnGrid && viewedPlayer.actionCards.any { it.kind == "DEFENSE" }
+    val isProtectedFromSwap = swapState != null && !isOwnGrid && viewedPlayerHasDefense
+
     val isSelectableOtherGrid = when (val state = swapState) {
-        is SwapSelectionState.AwaitingFirst -> !state.ownCardsOnly
+        is SwapSelectionState.AwaitingFirst -> !state.ownCardsOnly && !isProtectedFromSwap
         is SwapSelectionState.AwaitingSecond -> !state.ownCardsOnly &&
-                state.player1Id != viewedPlayer.playerId
+                state.player1Id != viewedPlayer.playerId && !isProtectedFromSwap
         null -> false
     }
 
@@ -694,9 +713,50 @@ private fun PlayerGridCarousel(
 
             Spacer(modifier = Modifier.height(12.dp))
 
+            if (peekedSlots.isNotEmpty()) {
+                val peekTargetLabel = peekResult?.let { r ->
+                    when (r.targetType) {
+                        BoardLineTargetType.ROW -> "Row ${r.lineIndex}"
+                        BoardLineTargetType.COLUMN -> "Column ${r.lineIndex}"
+                    }
+                } ?: ""
+                Surface(
+                    shape = MaterialTheme.shapes.medium,
+                    color = BlueSurface,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("peek_banner"),
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column {
+                            Text(
+                                text = "Private Peek",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = PrimaryGreen,
+                                fontWeight = FontWeight.Bold,
+                            )
+                            Text(
+                                text = peekTargetLabel,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MutedText,
+                            )
+                        }
+                        TextButton(onClick = onDismissPeek) {
+                            Text(text = "Got it", color = PrimaryGreen)
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
             if (isOwnGrid) {
                 CardGrid(
                     board = myBoard,
+                    peekedSlots = peekedSlots,
                     selectable = canSelectOwnForSwap || (isMyTurn && isReplacementPhase && pendingAction != null),
                     onCardClick = { row, col ->
                         if (canSelectOwnForSwap) {
@@ -748,7 +808,28 @@ private fun PlayerGridCarousel(
                     )
                 }
 
-                if (isSelectableOtherGrid) {
+                if (isProtectedFromSwap) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag("defense_protected_indicator"),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Shield,
+                            contentDescription = null,
+                            tint = MutedText,
+                            modifier = Modifier.size(16.dp),
+                        )
+                        Text(
+                            text = "Protected by Defense card — cannot swap",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MutedText,
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(4.dp))
+                } else if (isSelectableOtherGrid) {
                     Text(
                         text = "Tap a card to swap",
                         style = MaterialTheme.typography.labelSmall,
@@ -758,6 +839,7 @@ private fun PlayerGridCarousel(
                 }
                 CardGrid(
                     board = viewedPlayer.board,
+                    peekedSlots = peekedSlots,
                     selectable = isSelectableOtherGrid,
                     onCardClick = { row, col ->
                         onOtherSlotSelected(viewedPlayer.playerId, row, col)
@@ -1122,6 +1204,7 @@ private fun CardGrid(
     board: List<List<BoardSlot>>,
     selectable: Boolean,
     onCardClick: (row: Int, col: Int) -> Unit,
+    peekedSlots: Map<Pair<Int, Int>, Int?> = emptyMap(),
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -1134,10 +1217,13 @@ private fun CardGrid(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 row.forEachIndexed { colIndex, slot ->
+                    val key = Pair(rowIndex, colIndex)
                     BoardSlotTile(
                         slot = slot,
                         selectable = selectable && slot.type == "OCCUPIED",
                         onClick = { onCardClick(rowIndex, colIndex) },
+                        isPeeked = peekedSlots.containsKey(key),
+                        peekedValue = peekedSlots[key],
                         modifier = Modifier
                             .weight(1f)
                             .testTag("board_slot_${rowIndex}_${colIndex}"),
@@ -1153,6 +1239,8 @@ private fun BoardSlotTile(
     slot: BoardSlot,
     selectable: Boolean,
     onClick: () -> Unit,
+    isPeeked: Boolean = false,
+    peekedValue: Int? = null,
     modifier: Modifier = Modifier,
 ) {
     when (slot.type) {
@@ -1168,15 +1256,28 @@ private fun BoardSlotTile(
             val isFaceUp = slot.faceUp == true
             val cardValue = if (isFaceUp) slot.card?.value else null
             val bgColor = when {
+                isPeeked -> BlueSurface
                 !isFaceUp -> CardHiddenBg
                 cardValue != null && cardValue <= 0 -> CardNegativeBg
                 else -> CardPositiveBg
             }
             val displayText = when {
+                isPeeked -> peekedValue?.toString() ?: "?"
                 !isFaceUp -> "?"
                 slot.card?.type == "ACTION" -> "A"
                 cardValue != null -> cardValue.toString()
                 else -> "?"
+            }
+            val borderColor = when {
+                selectable -> PrimaryGreen
+                isPeeked -> MintGreen
+                !isFaceUp -> MintGreen.copy(alpha = 0.4f)
+                else -> BorderColor
+            }
+            val textColor = when {
+                isPeeked -> PrimaryGreen
+                !isFaceUp -> CardHiddenText
+                else -> MaterialTheme.colorScheme.onBackground
             }
 
             Box(
@@ -1184,10 +1285,8 @@ private fun BoardSlotTile(
                     .aspectRatio(0.65f)
                     .background(color = bgColor, shape = RoundedCornerShape(10.dp))
                     .border(
-                        width = if (selectable) 2.dp else 1.dp,
-                        color = if (selectable) PrimaryGreen
-                        else if (!isFaceUp) MintGreen.copy(alpha = 0.4f)
-                        else BorderColor,
+                        width = if (selectable || isPeeked) 2.dp else 1.dp,
+                        color = borderColor,
                         shape = RoundedCornerShape(10.dp),
                     )
                     .then(if (selectable) Modifier.clickable(onClick = onClick) else Modifier),
@@ -1196,7 +1295,7 @@ private fun BoardSlotTile(
                 Text(
                     text = displayText,
                     style = MaterialTheme.typography.titleLarge,
-                    color = if (!isFaceUp) CardHiddenText else MaterialTheme.colorScheme.onBackground,
+                    color = textColor,
                     fontWeight = FontWeight.ExtraBold,
                     textAlign = TextAlign.Center,
                 )
@@ -1562,46 +1661,6 @@ private fun EnlightenmentTargetPicker(
     }
 }
 
-@Composable
-private fun EnlightenmentResultDialog(
-    result: ActionCardResultMessage,
-    onDismiss: () -> Unit,
-) {
-    val targetLabel = when (result.targetType) {
-        BoardLineTargetType.ROW -> "Row ${result.lineIndex}"
-        BoardLineTargetType.COLUMN -> "Column ${result.lineIndex}"
-    }
-    val valuesLabel = if (result.inspectedValues.isEmpty()) {
-        "No cards inspected"
-    } else {
-        "Values: ${result.inspectedValues.joinToString { it?.toString() ?: "?" }}"
-    }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = {
-            Text(text = "Private Peek")
-        },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(
-                    text = "Enlightenment result for $targetLabel",
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                Text(
-                    text = valuesLabel,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(text = "OK")
-            }
-        },
-    )
-}
 
 @Composable
 private fun HandActionCardsRow(
@@ -1765,6 +1824,18 @@ private fun actionCardAccessibilityLabel(card: ActionCard): String =
         ACTION_CARD_KIND_ENLIGHTENMENT -> "Enlightenment"
         else -> card.label.ifBlank { "Action" }
     }
+
+private fun ActionCardResultMessage.toPeekedSlots(): Map<Pair<Int, Int>, Int?> {
+    if (inspectedCards.isNotEmpty()) {
+        return inspectedCards.associate { Pair(it.row, it.col) to it.value }
+    }
+    return when (targetType) {
+        BoardLineTargetType.ROW ->
+            inspectedValues.mapIndexed { col, value -> Pair(lineIndex, col) to value }.toMap()
+        BoardLineTargetType.COLUMN ->
+            inspectedValues.mapIndexed { row, value -> Pair(row, lineIndex) to value }.toMap()
+    }
+}
 
 @Composable
 private fun ActionCardFaceContent(

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
@@ -383,6 +383,8 @@ private fun GameContent(
         myPlayerId = myPlayerId ?: "",
         myBoard = myBoard ?: emptyList(),
         myVisibleScore = myVisibleScore,
+        totalScores = gameState.totalScores,
+        disconnectedPlayers = gameState.disconnectedPlayers,
         isMyTurn = isMyTurn,
         isReplacementPhase = isReplacementPhase,
         pendingAction = pendingAction,
@@ -583,6 +585,8 @@ private fun PlayerGridCarousel(
     myPlayerId: String,
     myBoard: List<List<BoardSlot>>,
     myVisibleScore: Int,
+    totalScores: List<TotalScore>,
+    disconnectedPlayers: List<String>,
     isMyTurn: Boolean,
     isReplacementPhase: Boolean,
     pendingAction: String?,
@@ -705,6 +709,38 @@ private fun PlayerGridCarousel(
                     },
                 )
             } else {
+                val isDisconnected = viewedPlayer.nickname in disconnectedPlayers
+                val playerScore = totalScores.find { it.playerId == viewedPlayer.playerId }?.totalScore ?: 0
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (isDisconnected) {
+                        Surface(
+                            shape = MaterialTheme.shapes.extraLarge,
+                            color = Color(0xFFFFCDD2),
+                        ) {
+                            Text(
+                                text = "Disconnected",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = Color(0xFFB71C1C),
+                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = "$playerScore pts",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MutedText,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+
                 if (isSelectableOtherGrid) {
                     Text(
                         text = "Tap a card to swap",
@@ -1683,117 +1719,6 @@ private fun DiscardActionCardButton(
             textAlign = TextAlign.Center,
             modifier = Modifier.padding(vertical = 6.dp),
         )
-    }
-}
-
-@Composable
-private fun OtherPlayerRow(
-    player: GamePlayerState,
-    totalScore: Int,
-    isCurrentPlayer: Boolean,
-    isDisconnected: Boolean = false,
-    swapState: SwapSelectionState?,
-    onSlotSelected: (row: Int, col: Int) -> Unit,
-) {
-    val avatarBg = when {
-        isDisconnected -> Color(0xFFFFCDD2)
-        isCurrentPlayer -> MintGreen
-        else -> MaterialTheme.colorScheme.surfaceVariant
-    }
-    val avatarTextColor = when {
-        isDisconnected -> Color(0xFFB71C1C)
-        isCurrentPlayer -> PrimaryGreen
-        else -> MutedText
-    }
-    val surfaceColor = when {
-        isDisconnected -> Color(0xFFFFF8F8)
-        isCurrentPlayer -> at.aau.se2.skyjo.ui.theme.GreenSurface
-        else -> MaterialTheme.colorScheme.surface
-    }
-    val border = when {
-        isDisconnected -> androidx.compose.foundation.BorderStroke(1.dp, Color(0xFFEF9A9A))
-        isCurrentPlayer -> androidx.compose.foundation.BorderStroke(1.dp, PrimaryGreen)
-        else -> null
-    }
-    val isSelectableForSwap = when (val state = swapState) {
-        is SwapSelectionState.AwaitingFirst -> !state.ownCardsOnly
-        is SwapSelectionState.AwaitingSecond -> !state.ownCardsOnly && state.player1Id != player.playerId
-        null -> false
-    }
-
-    Surface(
-        shape = MaterialTheme.shapes.medium,
-        color = surfaceColor,
-        border = if (isSelectableForSwap) {
-            androidx.compose.foundation.BorderStroke(2.dp, PrimaryGreen)
-        } else {
-            border
-        },
-    ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
-            Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = player.nickname.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
-                style = MaterialTheme.typography.titleMedium,
-                color = avatarTextColor,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier
-                    .size(36.dp)
-                    .background(
-                        color = avatarBg,
-                        shape = androidx.compose.foundation.shape.CircleShape
-                    )
-                    .padding(8.dp),
-                textAlign = TextAlign.Center,
-            )
-            Spacer(modifier = Modifier.width(12.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = player.nickname,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = if (isCurrentPlayer) FontWeight.Bold else FontWeight.Normal,
-                    color = if (isDisconnected) Color(0xFFB71C1C) else MaterialTheme.colorScheme.onSurface,
-                )
-                if (isDisconnected) {
-                    Text(
-                        text = "Disconnected",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = Color(0xFFEF5350),
-                    )
-                }
-                if (isSelectableForSwap) {
-                    Text(
-                        text = "Tap a card to swap",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = PrimaryGreen,
-                    )
-                }
-            }
-            Text(
-                text = "$totalScore pts",
-                style = MaterialTheme.typography.labelLarge,
-                color = when {
-                    isDisconnected -> Color(0xFFEF9A9A)
-                    isCurrentPlayer -> PrimaryGreen
-                    else -> MutedText
-                },
-                fontWeight = FontWeight.Bold,
-            )
-        }
-            if (isSelectableForSwap) {
-                CardGrid(
-                    board = player.board,
-                    selectable = true,
-                    onCardClick = onSlotSelected,
-                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-                )
-            }
-        }
     }
 }
 

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -644,6 +645,154 @@ private fun OtherPlayersSection(
                     isDisconnected = player.nickname in disconnectedPlayers,
                     swapState = swapState,
                     onSlotSelected = { row, col -> onSlotSelected(player.playerId, row, col) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayerGridCarousel(
+    players: List<GamePlayerState>,
+    myPlayerId: String,
+    myBoard: List<List<BoardSlot>>,
+    myVisibleScore: Int,
+    isMyTurn: Boolean,
+    isReplacementPhase: Boolean,
+    pendingAction: String?,
+    swapState: SwapSelectionState?,
+    viewedPlayerIndex: Int,
+    onViewedPlayerIndexChange: (Int) -> Unit,
+    onPendingActionChange: (String?) -> Unit,
+    onReplaceCard: (row: Int, col: Int) -> Unit,
+    onDiscardAndReveal: (row: Int, col: Int) -> Unit,
+    onSwapSlotSelected: (row: Int, col: Int) -> Unit,
+    onOtherSlotSelected: (playerId: String, row: Int, col: Int) -> Unit,
+) {
+    if (players.isEmpty()) return
+    val pageCount = players.size
+    val safeIndex = viewedPlayerIndex.coerceIn(0, players.lastIndex)
+    val viewedPlayer = players[safeIndex]
+    val isOwnGrid = viewedPlayer.playerId == myPlayerId
+
+    val canSelectOwnForSwap = when (val state = swapState) {
+        is SwapSelectionState.AwaitingFirst -> myPlayerId.isNotBlank()
+        is SwapSelectionState.AwaitingSecond -> myPlayerId.isNotBlank() &&
+                (state.ownCardsOnly || state.player1Id != myPlayerId)
+        null -> false
+    }
+
+    val isSelectableOtherGrid = when (val state = swapState) {
+        is SwapSelectionState.AwaitingFirst -> !state.ownCardsOnly
+        is SwapSelectionState.AwaitingSecond -> !state.ownCardsOnly &&
+                state.player1Id != viewedPlayer.playerId
+        null -> false
+    }
+
+    Surface(
+        shape = MaterialTheme.shapes.large,
+        color = SurfaceWhite,
+        shadowElevation = 2.dp,
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(
+                    onClick = { onViewedPlayerIndexChange((safeIndex - 1 + pageCount) % pageCount) },
+                    modifier = Modifier.testTag("carousel_prev"),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = "Previous player",
+                        tint = PrimaryGreen,
+                    )
+                }
+
+                Column(
+                    modifier = Modifier.weight(1f),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = if (isOwnGrid) "Your Grid" else "${viewedPlayer.nickname}'s Grid",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.Center,
+                    )
+                    Text(
+                        text = "(${safeIndex + 1}/$pageCount)",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MutedText,
+                    )
+                }
+
+                if (isOwnGrid) {
+                    Surface(
+                        shape = MaterialTheme.shapes.extraLarge,
+                        color = at.aau.se2.skyjo.ui.theme.GreenSurface,
+                    ) {
+                        Text(
+                            text = "Visible: $myVisibleScore",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = PrimaryGreen,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                        )
+                    }
+                }
+
+                IconButton(
+                    onClick = { onViewedPlayerIndexChange((safeIndex + 1) % pageCount) },
+                    modifier = Modifier.testTag("carousel_next"),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowForward,
+                        contentDescription = "Next player",
+                        tint = PrimaryGreen,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            if (isOwnGrid) {
+                CardGrid(
+                    board = myBoard,
+                    selectable = canSelectOwnForSwap || (isMyTurn && isReplacementPhase && pendingAction != null),
+                    onCardClick = { row, col ->
+                        if (canSelectOwnForSwap) {
+                            onSwapSlotSelected(row, col)
+                        } else {
+                            when (pendingAction) {
+                                "REPLACE" -> {
+                                    onReplaceCard(row, col)
+                                    onPendingActionChange(null)
+                                }
+                                "DISCARD_AND_REVEAL" -> {
+                                    onDiscardAndReveal(row, col)
+                                    onPendingActionChange(null)
+                                }
+                            }
+                        }
+                    },
+                )
+            } else {
+                if (isSelectableOtherGrid) {
+                    Text(
+                        text = "Tap a card to swap",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = PrimaryGreen,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+                CardGrid(
+                    board = viewedPlayer.board,
+                    selectable = isSelectableOtherGrid,
+                    onCardClick = { row, col ->
+                        onOtherSlotSelected(viewedPlayer.playerId, row, col)
+                    },
                 )
             }
         }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
@@ -63,6 +63,7 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
 
     fun leaveLobby() {
         gameClient.leaveLobby()
+        gameClient.clearStoredGame()
         gameClient.disconnect()
         _myPlayerName.value = ""
     }

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHostTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHostTest.kt
@@ -204,6 +204,10 @@ class AppNavHostTest {
         composeTestRule.onAllNodesWithText("3").onFirst().performScrollTo().performClick()
         composeTestRule.waitForIdle()
 
+        // Navigate to Bob's grid in carousel
+        composeTestRule.onNodeWithTag("carousel_next").performScrollTo().performClick()
+        composeTestRule.waitForIdle()
+
         // Select second card from Bob's board
         composeTestRule.onAllNodesWithText("5").onFirst().performScrollTo().performClick()
         composeTestRule.waitForIdle()

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
@@ -833,6 +833,8 @@ class GameScreenTest {
                 )
             }
         }
+        // Navigate to Bob's grid to see disconnected badge
+        composeTestRule.onNodeWithTag("carousel_next").performScrollTo().performClick()
         composeTestRule.onNodeWithText("Disconnected").assertExists()
     }
 

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
@@ -16,6 +16,7 @@ import at.aau.se2.skyjo.model.ActionCardResultMessage
 import at.aau.se2.skyjo.model.BoardLineTargetType
 import at.aau.se2.skyjo.model.BoardSlot
 import at.aau.se2.skyjo.model.Card
+import at.aau.se2.skyjo.model.InspectedCard
 import at.aau.se2.skyjo.model.GamePlayerState
 import at.aau.se2.skyjo.model.GameUpdateMessage
 import at.aau.se2.skyjo.model.PlayerRoundScore
@@ -486,6 +487,83 @@ class GameScreenTest {
             .performClick()
 
         assertEquals(PlayerSwapCall(0, "p2", 0, 0, "p1", 0, 1), playerSwapCall)
+    }
+
+    @Test
+    fun gameScreen_player_swap_shows_protected_indicator_when_target_has_defense() {
+        composeTestRule.setContent {
+            SkyjoTheme {
+                GameScreen(
+                    gameState = makeGameState(
+                        handActionCards = listOf(ActionCard(id = 152, kind = "PLAYER_SWAP")),
+                    ).copy(
+                        players = listOf(
+                            GamePlayerState(
+                                playerId = "p1",
+                                nickname = "Alice",
+                                board = List(3) { List(4) { BoardSlot(type = "OCCUPIED", faceUp = false) } },
+                                actionCards = listOf(ActionCard(id = 152, kind = "PLAYER_SWAP")),
+                            ),
+                            GamePlayerState(
+                                playerId = "p2",
+                                nickname = "Bob",
+                                board = List(3) { List(4) { BoardSlot(type = "OCCUPIED", faceUp = false) } },
+                                actionCards = listOf(ActionCard(id = 151, kind = "DEFENSE")),
+                            ),
+                        ),
+                    ),
+                    myPlayerId = "p1",
+                    isMyTurn = true,
+                    onBack = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("play_action_card_0").performScrollTo().performClick()
+        composeTestRule.onNodeWithTag("carousel_next").performScrollTo().performClick()
+
+        composeTestRule.onNodeWithTag("defense_protected_indicator").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("Protected by Defense card — cannot swap").assertIsDisplayed()
+        assertTextAbsent("Tap a card to swap")
+    }
+
+    @Test
+    fun gameScreen_player_swap_grid_not_selectable_when_target_has_defense() {
+        var swapCalled = false
+        composeTestRule.setContent {
+            SkyjoTheme {
+                GameScreen(
+                    gameState = makeGameState(
+                        handActionCards = listOf(ActionCard(id = 152, kind = "PLAYER_SWAP")),
+                    ).copy(
+                        players = listOf(
+                            GamePlayerState(
+                                playerId = "p1",
+                                nickname = "Alice",
+                                board = List(3) { List(4) { BoardSlot(type = "OCCUPIED", faceUp = false) } },
+                                actionCards = listOf(ActionCard(id = 152, kind = "PLAYER_SWAP")),
+                            ),
+                            GamePlayerState(
+                                playerId = "p2",
+                                nickname = "Bob",
+                                board = List(3) { List(4) { BoardSlot(type = "OCCUPIED", faceUp = false) } },
+                                actionCards = listOf(ActionCard(id = 151, kind = "DEFENSE")),
+                            ),
+                        ),
+                    ),
+                    myPlayerId = "p1",
+                    isMyTurn = true,
+                    onPlayPlayerSwapCard = { _, _, _, _, _, _, _ -> swapCalled = true },
+                    onBack = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("play_action_card_0").performScrollTo().performClick()
+        composeTestRule.onNodeWithTag("carousel_next").performScrollTo().performClick()
+        composeTestRule.onNodeWithTag("board_slot_0_0").performScrollTo().performClick()
+
+        assertEquals(false, swapCalled)
     }
 
     @Test
@@ -1008,11 +1086,11 @@ class GameScreenTest {
     }
 
     @Test
-    fun gameScreen_private_enlightenment_result_shows_inspected_values() {
+    fun gameScreen_enlightenment_result_shows_peeked_value_in_grid_via_inspected_cards() {
         composeTestRule.setContent {
             SkyjoTheme {
                 GameScreen(
-                    gameState = makeGameState(),
+                    gameState = makeGameStateWithHiddenCardValues(),
                     myPlayerId = "p1",
                     isMyTurn = true,
                     privateActionCardResult = ActionCardResultMessage(
@@ -1021,23 +1099,81 @@ class GameScreenTest {
                         targetPlayerId = "p1",
                         targetType = BoardLineTargetType.ROW,
                         lineIndex = 0,
-                        inspectedValues = listOf(2, null, 6, 8),
+                        inspectedCards = listOf(
+                            InspectedCard(row = 0, col = 0, value = 11),
+                            InspectedCard(row = 0, col = 2, value = 7),
+                            InspectedCard(row = 0, col = 3, value = -2),
+                        ),
                     ),
                     onBack = {},
                 )
             }
         }
 
-        composeTestRule.onNodeWithText("Private Peek").assertExists()
-        composeTestRule.onNodeWithText("Values: 2, ?, 6, 8").assertExists()
+        composeTestRule.onNodeWithText("11").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("7").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("-2").performScrollTo().assertIsDisplayed()
     }
 
     @Test
-    fun gameScreen_private_enlightenment_result_shows_empty_state() {
+    fun gameScreen_enlightenment_result_shows_peeked_values_from_inspected_values_fallback() {
         composeTestRule.setContent {
             SkyjoTheme {
                 GameScreen(
-                    gameState = makeGameState(),
+                    gameState = makeGameStateWithHiddenCardValues(),
+                    myPlayerId = "p1",
+                    isMyTurn = true,
+                    privateActionCardResult = ActionCardResultMessage(
+                        type = "ENLIGHTENMENT",
+                        actionCardIndex = 0,
+                        targetPlayerId = "p1",
+                        targetType = BoardLineTargetType.ROW,
+                        lineIndex = 1,
+                        inspectedValues = listOf(5, 9, 3, 1),
+                    ),
+                    onBack = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("9").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("1").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun gameScreen_enlightenment_result_shows_peek_banner() {
+        composeTestRule.setContent {
+            SkyjoTheme {
+                GameScreen(
+                    gameState = makeGameStateWithHiddenCardValues(),
+                    myPlayerId = "p1",
+                    isMyTurn = true,
+                    privateActionCardResult = ActionCardResultMessage(
+                        type = "ENLIGHTENMENT",
+                        actionCardIndex = 0,
+                        targetPlayerId = "p1",
+                        targetType = BoardLineTargetType.ROW,
+                        lineIndex = 0,
+                        inspectedCards = listOf(InspectedCard(row = 0, col = 0, value = 4)),
+                    ),
+                    onBack = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("peek_banner").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("Private Peek").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("Row 0").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("Got it").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun gameScreen_enlightenment_result_dismiss_calls_callback() {
+        var dismissed = false
+        composeTestRule.setContent {
+            SkyjoTheme {
+                GameScreen(
+                    gameState = makeGameStateWithHiddenCardValues(),
                     myPlayerId = "p1",
                     isMyTurn = true,
                     privateActionCardResult = ActionCardResultMessage(
@@ -1045,15 +1181,42 @@ class GameScreenTest {
                         actionCardIndex = 0,
                         targetPlayerId = "p1",
                         targetType = BoardLineTargetType.COLUMN,
-                        lineIndex = 1,
+                        lineIndex = 2,
+                        inspectedCards = listOf(InspectedCard(row = 0, col = 2, value = 6)),
+                    ),
+                    onDismissActionCardResult = { dismissed = true },
+                    onBack = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Got it").performScrollTo().performClick()
+        assertEquals(true, dismissed)
+    }
+
+    @Test
+    fun gameScreen_enlightenment_result_auto_navigates_to_target_player() {
+        composeTestRule.setContent {
+            SkyjoTheme {
+                GameScreen(
+                    gameState = makeGameStateWithHiddenCardValues(),
+                    myPlayerId = "p1",
+                    isMyTurn = true,
+                    privateActionCardResult = ActionCardResultMessage(
+                        type = "ENLIGHTENMENT",
+                        actionCardIndex = 0,
+                        targetPlayerId = "p2",
+                        targetType = BoardLineTargetType.ROW,
+                        lineIndex = 0,
+                        inspectedCards = listOf(InspectedCard(row = 0, col = 0, value = 3)),
                     ),
                     onBack = {},
                 )
             }
         }
 
-        composeTestRule.onNodeWithText("Private Peek").assertExists()
-        composeTestRule.onNodeWithText("No cards inspected").assertExists()
+        composeTestRule.onNodeWithTag("peek_banner").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("Bob's Grid").performScrollTo().assertIsDisplayed()
     }
 
     private fun assertTextAbsent(text: String) {
@@ -1153,7 +1316,7 @@ class GameScreenTest {
         drawnCard = drawnCard,
         visibleActionCards = listOf(
             ActionCard(id = 151, kind = "DEFENSE"),
-            ActionCard(id = 152, kind = "PLACEHOLDER"),
+            ActionCard(id = 152, kind = "PLACEHOLDER"), // Sprint 3: replace with real card kind
         ),
         actionDrawPileCount = 16,
         roundResult = roundResult,

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
@@ -292,7 +292,7 @@ class GameScreenTest {
             }
         }
 
-        composeTestRule.onAllNodesWithText("🛡️").assertCountEquals(2)
+        composeTestRule.onAllNodesWithText("Defense").assertCountEquals(2)
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreenTest.kt
@@ -338,6 +338,8 @@ class GameScreenTest {
             .performScrollTo()
             .performClick()
 
+        // Navigate to Bob's grid to see the swap hint
+        composeTestRule.onNodeWithTag("carousel_next").performScrollTo().performClick()
         composeTestRule.onNodeWithText("Tap a card to swap").performScrollTo().assertIsDisplayed()
         assertEquals(null, playedIndex)
     }
@@ -465,15 +467,19 @@ class GameScreenTest {
             }
         }
 
+        // Play PLAYER_SWAP card
         composeTestRule
             .onNodeWithTag("play_action_card_0")
             .performScrollTo()
             .performClick()
+        // Navigate to Bob's grid and select his slot (AwaitingFirst → AwaitingSecond with player1=p2)
+        composeTestRule.onNodeWithTag("carousel_next").performScrollTo().performClick()
         composeTestRule
-            .onAllNodesWithTag("board_slot_0_0")
-            .onLast()
+            .onNodeWithTag("board_slot_0_0")
             .performScrollTo()
             .performClick()
+        // Navigate back to Alice's grid and select her slot (fires onPlayPlayerSwapCard)
+        composeTestRule.onNodeWithTag("carousel_next").performScrollTo().performClick()
         composeTestRule
             .onNodeWithTag("board_slot_0_1")
             .performScrollTo()
@@ -591,7 +597,7 @@ class GameScreenTest {
     }
 
     @Test
-    fun gameScreen_shows_other_players_section() {
+    fun gameScreen_carousel_shows_own_grid_by_default() {
         composeTestRule.setContent {
             SkyjoTheme {
                 GameScreen(
@@ -602,7 +608,43 @@ class GameScreenTest {
                 )
             }
         }
-        composeTestRule.onNodeWithText("Other Players").assertExists()
+        composeTestRule.onNodeWithText("Your Grid").assertExists()
+        composeTestRule.onNodeWithText("(1/2)").assertExists()
+    }
+
+    @Test
+    fun gameScreen_carousel_next_navigates_to_other_player() {
+        composeTestRule.setContent {
+            SkyjoTheme {
+                GameScreen(
+                    gameState = makeGameState(),
+                    myPlayerId = "p1",
+                    isMyTurn = false,
+                    onBack = {},
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("carousel_next").performScrollTo().performClick()
+        composeTestRule.onNodeWithText("Bob's Grid").assertExists()
+        composeTestRule.onNodeWithText("(2/2)").assertExists()
+    }
+
+    @Test
+    fun gameScreen_carousel_wraps_from_last_to_first() {
+        composeTestRule.setContent {
+            SkyjoTheme {
+                GameScreen(
+                    gameState = makeGameState(),
+                    myPlayerId = "p1",
+                    isMyTurn = false,
+                    onBack = {},
+                )
+            }
+        }
+        // Navigate forward past end → wraps to start
+        composeTestRule.onNodeWithTag("carousel_next").performScrollTo().performClick()
+        composeTestRule.onNodeWithTag("carousel_next").performScrollTo().performClick()
+        composeTestRule.onNodeWithText("Your Grid").assertExists()
     }
 
     @Test
@@ -866,7 +908,7 @@ class GameScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Enlightenment").performScrollTo().performClick()
+        composeTestRule.onNodeWithTag("play_action_card_0").performScrollTo().performClick()
 
         composeTestRule.onNodeWithText("Select a target player, then a row or column").assertExists()
         composeTestRule.onNodeWithText("Alice (You)").assertExists()
@@ -888,7 +930,7 @@ class GameScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Enlightenment").performScrollTo().assertExists()
+        composeTestRule.onNodeWithTag("play_action_card_0").performScrollTo().assertExists()
 
         assertTextAbsent("Select a target player, then a row or column")
         assertTextAbsent("Row 0")
@@ -910,7 +952,7 @@ class GameScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Enlightenment").performScrollTo().performClick()
+        composeTestRule.onNodeWithTag("play_action_card_0").performScrollTo().performClick()
         composeTestRule.onNodeWithText("Row 0").performScrollTo().performClick()
 
         assertEquals(0, sentCommand?.actionCardIndex)
@@ -935,7 +977,7 @@ class GameScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Enlightenment").performScrollTo().performClick()
+        composeTestRule.onNodeWithTag("play_action_card_0").performScrollTo().performClick()
         composeTestRule.onNodeWithText("Target Bob").performScrollTo().performClick()
         composeTestRule.onNodeWithText("Target: Bob").assertExists()
         composeTestRule.onNodeWithText("Row 0").performScrollTo().performClick()
@@ -957,7 +999,7 @@ class GameScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Enlightenment").performScrollTo().performClick()
+        composeTestRule.onNodeWithTag("play_action_card_0").performScrollTo().performClick()
         composeTestRule.onNodeWithText("Cancel").performScrollTo().performClick()
 
         assertTextAbsent("Select a target player, then a row or column")


### PR DESCRIPTION
## Summary

- Replace \"Your Grid\" + \"Other Players\" sections with a single `PlayerGridCarousel` — ← → arrows let players navigate between all player grids one at a time, with page indicator and \"Visible: N\" score badge on own grid
- Show disconnected badge + opponent score when viewing another player's grid in the carousel
- Add action card name below symbol in hand cards (e.g. \"Player swap\", \"Enlightenment\") so players know what each card does

## Test plan

- [x] Carousel defaults to own grid on turn start
- [x] Arrow navigation cycles through all players, wraps around
- [x] \"Tap a card to swap\" hint appears on other player's grid during PLAYER_SWAP
- [x] Swap flows work: PLAYER_SWAP (cross-player), SWAP_OWN_CARDS (own cards)
- [x] Disconnected badge visible when navigating to disconnected player's grid
- [x] Action card names visible below symbols in hand cards section
- [x] ACTION MARKET cards unchanged (no name labels there)
- [x] All existing test suite passes