### PR TITLE
Add authenticated lobby frontend

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,9 +37,16 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "HTTP_BASE_URL", "\"http://se2-demo.aau.at:53209\"")
+        buildConfigField("String", "WS_BASE_URL", "\"ws://se2-demo.aau.at:53209/ws\"")
     }
 
     buildTypes {
+        debug {
+            buildConfigField("String", "HTTP_BASE_URL", "\"http://10.0.2.2:8080\"")
+            buildConfigField("String", "WS_BASE_URL", "\"ws://10.0.2.2:8080/ws\"")
+        }
+
         release {
             isMinifyEnabled = true
             proguardFiles(
@@ -78,6 +85,7 @@ android {
     buildFeatures {
         viewBinding = true
         compose = true
+        buildConfig = true
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -140,6 +140,7 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.activity:activity-compose:1.9.0")
     implementation("androidx.navigation:navigation-compose:$navigationComposeVersion")
+    implementation("androidx.security:security-crypto:1.1.0")
     debugImplementation("androidx.compose.ui:ui-tooling")
 
     // WebSocket

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,11 +42,6 @@ android {
     }
 
     buildTypes {
-        debug {
-            buildConfigField("String", "HTTP_BASE_URL", "\"http://10.0.2.2:8080\"")
-            buildConfigField("String", "WS_BASE_URL", "\"ws://10.0.2.2:8080/ws\"")
-        }
-
         release {
             isMinifyEnabled = true
             proguardFiles(

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,10 @@ android {
     }
 
     buildTypes {
+        debug {
+            buildConfigField("String", "HTTP_BASE_URL", "\"http://10.0.2.2:8080\"")
+            buildConfigField("String", "WS_BASE_URL", "\"ws://10.0.2.2:8080/ws\"")
+        }
         release {
             isMinifyEnabled = true
             proguardFiles(

--- a/app/src/main/kotlin/at/aau/se2/skyjo/MainActivity.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/MainActivity.kt
@@ -6,12 +6,18 @@ import androidx.activity.compose.setContent
 import androidx.navigation.compose.rememberNavController
 import at.aau.se2.skyjo.ui.navigation.AppNavHost
 import at.aau.se2.skyjo.ui.theme.SkyjoTheme
+import at.aau.se2.skyjo.viewmodel.AuthViewModel
+import at.aau.se2.skyjo.viewmodel.FriendsViewModel
 import at.aau.se2.skyjo.viewmodel.GameViewModel
+import at.aau.se2.skyjo.viewmodel.LeaderboardViewModel
 import androidx.activity.viewModels
 
 class MainActivity : ComponentActivity() {
 
+    private val authViewModel: AuthViewModel by viewModels()
     private val gameViewModel: GameViewModel by viewModels()
+    private val friendsViewModel: FriendsViewModel by viewModels()
+    private val leaderboardViewModel: LeaderboardViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -20,7 +26,10 @@ class MainActivity : ComponentActivity() {
                 val navController = rememberNavController()
                 AppNavHost(
                     navController = navController,
-                    gameViewModel = gameViewModel
+                    authViewModel = authViewModel,
+                    gameViewModel = gameViewModel,
+                    friendsViewModel = friendsViewModel,
+                    leaderboardViewModel = leaderboardViewModel,
                 )
             }
         }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/model/GameUpdateMessage.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/model/GameUpdateMessage.kt
@@ -66,5 +66,6 @@ data class GameUpdateMessage(
     val actionDrawPileCount: Int = 0,
     val roundResult: RoundResult? = null,
     val gameId: String? = null,
+    val lobbyId: String? = null,
     val disconnectedPlayers: List<String> = emptyList(),
 )

--- a/app/src/main/kotlin/at/aau/se2/skyjo/model/LobbyUpdateMessage.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/model/LobbyUpdateMessage.kt
@@ -10,6 +10,8 @@ data class LobbyPlayer(
 
 @Serializable
 data class LobbyUpdateMessage(
+    val lobbyId: String? = null,
+    val joinCode: String? = null,
     val players: List<LobbyPlayer>,
     val status: String,
     val maxPlayers: Int

--- a/app/src/main/kotlin/at/aau/se2/skyjo/model/auth/AuthModels.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/model/auth/AuthModels.kt
@@ -1,0 +1,21 @@
+package at.aau.se2.skyjo.model.auth
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterRequest(val username: String, val password: String)
+
+@Serializable
+data class LoginRequest(val username: String, val password: String)
+
+@Serializable
+data class AuthResponse(val token: String, val user: AuthUserDto)
+
+@Serializable
+data class AuthUserDto(val userId: String, val username: String)
+
+@Serializable
+data class WsTicketResponse(val ticket: String, val expiresAt: Long)
+
+@Serializable
+data class ErrorResponse(val message: String)

--- a/app/src/main/kotlin/at/aau/se2/skyjo/model/lobby/LobbyApiModels.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/model/lobby/LobbyApiModels.kt
@@ -1,0 +1,13 @@
+package at.aau.se2.skyjo.model.lobby
+
+import at.aau.se2.skyjo.model.LobbyPlayer
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LobbySummaryResponse(
+    val lobbyId: String,
+    val joinCode: String,
+    val players: List<LobbyPlayer>,
+    val status: String,
+    val maxPlayers: Int,
+)

--- a/app/src/main/kotlin/at/aau/se2/skyjo/model/social/SocialModels.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/model/social/SocialModels.kt
@@ -1,0 +1,74 @@
+package at.aau.se2.skyjo.model.social
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class FriendRequestStatus {
+    PENDING,
+    ACCEPTED,
+    DECLINED,
+}
+
+@Serializable
+enum class RelationshipStatus {
+    NONE,
+    FRIENDS,
+    INCOMING_REQUEST,
+    OUTGOING_REQUEST,
+}
+
+@Serializable
+data class SocialUserDto(
+    val userId: String,
+    val username: String,
+    val relationshipStatus: RelationshipStatus = RelationshipStatus.NONE,
+)
+
+@Serializable
+data class FriendDto(
+    val userId: String,
+    val username: String,
+    val online: Boolean,
+    val currentLobbyId: String? = null,
+)
+
+@Serializable
+data class FriendRequestDto(
+    val requestId: String,
+    val from: SocialUserDto,
+    val to: SocialUserDto,
+    val status: FriendRequestStatus,
+    val createdAt: Long,
+    val respondedAt: Long? = null,
+)
+
+@Serializable
+data class FriendRequestsResponse(
+    val incoming: List<FriendRequestDto>,
+    val outgoing: List<FriendRequestDto>,
+)
+
+@Serializable
+data class SendFriendRequestRequest(val toUserId: String)
+
+@Serializable
+enum class LobbyInviteStatus {
+    PENDING,
+    ACCEPTED,
+    DECLINED,
+}
+
+@Serializable
+data class LobbyInviteRequest(val toUserId: String)
+
+@Serializable
+data class LobbyInviteDto(
+    val inviteId: String,
+    val lobbyId: String,
+    val joinCode: String,
+    val from: SocialUserDto,
+    val to: SocialUserDto,
+    val status: LobbyInviteStatus,
+    val createdAt: Long,
+    val respondedAt: Long? = null,
+)

--- a/app/src/main/kotlin/at/aau/se2/skyjo/model/stats/StatsModels.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/model/stats/StatsModels.kt
@@ -1,0 +1,26 @@
+package at.aau.se2.skyjo.model.stats
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PlayerStatsDto(
+    val userId: String,
+    val username: String,
+    val gamesPlayed: Int,
+    val wins: Int,
+    val totalScore: Int,
+    val bestScore: Int? = null,
+    val averageScore: Double,
+)
+
+@Serializable
+data class LeaderboardEntryDto(
+    val rank: Int,
+    val userId: String,
+    val username: String,
+    val averageScore: Double,
+    val wins: Int,
+    val gamesPlayed: Int,
+    val bestScore: Int? = null,
+    val totalScore: Int,
+)

--- a/app/src/main/kotlin/at/aau/se2/skyjo/network/GameRealtimeClient.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/network/GameRealtimeClient.kt
@@ -1,0 +1,34 @@
+package at.aau.se2.skyjo.network
+
+import at.aau.se2.skyjo.model.ActionCardResultMessage
+import at.aau.se2.skyjo.model.GameAction
+import at.aau.se2.skyjo.model.GameUpdateMessage
+import at.aau.se2.skyjo.model.LobbyUpdateMessage
+import at.aau.se2.skyjo.model.PlayActionCardCommand
+import at.aau.se2.skyjo.model.social.LobbyInviteDto
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+
+interface GameRealtimeClient {
+    val lobbyState: StateFlow<LobbyUpdateMessage?>
+    val gameState: StateFlow<GameUpdateMessage?>
+    val actionCardResults: SharedFlow<ActionCardResultMessage>
+    val incomingInvites: SharedFlow<LobbyInviteDto>
+    val errorMessage: SharedFlow<String>
+    val connectionError: StateFlow<String?>
+    val isConnected: StateFlow<Boolean>
+    val hasRejoinedGame: StateFlow<Boolean>
+
+    suspend fun connect()
+    suspend fun connect(ticket: String?, lobbyJoinCode: String?)
+    suspend fun reconnect(playerName: String)
+    fun applyLobbyState(lobby: LobbyUpdateMessage)
+    fun joinLobby(playerName: String, gameId: String? = null)
+    fun leaveLobby()
+    fun startGame(maxRounds: Int, targetScore: Int)
+    fun sendAction(action: GameAction)
+    fun playActionCard(command: PlayActionCardCommand)
+    fun clearStoredGame()
+    fun disconnect()
+    fun close()
+}

--- a/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
@@ -159,8 +159,12 @@ class GameStompClient(context: Context) : GameRealtimeClient {
             flow.collect { jsonText ->
                 try {
                     val msg = json.decodeFromString<GameUpdateMessage>(jsonText)
-                    msg.gameId?.let { prefs.edit().putString(PREF_GAME_ID, it).apply() }
-                    msg.gameId?.let { subscribeGameTopic(it) }
+                    if (msg.gameOver) {
+                        clearStoredGame()
+                    } else {
+                        msg.gameId?.let { prefs.edit().putString(PREF_GAME_ID, it).apply() }
+                        msg.gameId?.let { subscribeGameTopic(it) }
+                    }
                     _gameState.value = msg
                 } catch (e: Exception) {
                     Log.e(TAG, "Game parse error: ${e.message}")
@@ -194,10 +198,15 @@ class GameStompClient(context: Context) : GameRealtimeClient {
             flow.collect { jsonText ->
                 try {
                     val msg = json.decodeFromString<GameUpdateMessage>(jsonText)
-                    msg.gameId?.let { prefs.edit().putString(PREF_GAME_ID, it).apply() }
-                    msg.gameId?.let { subscribeGameTopic(it) }
                     _gameState.value = msg
-                    _hasRejoinedGame.value = true
+                    if (msg.isRejoinable()) {
+                        msg.gameId?.let { prefs.edit().putString(PREF_GAME_ID, it).apply() }
+                        msg.gameId?.let { subscribeGameTopic(it) }
+                        _hasRejoinedGame.value = true
+                    } else {
+                        clearStoredGame()
+                        _hasRejoinedGame.value = false
+                    }
                 } catch (e: Exception) {
                     Log.e(TAG, "Rejoin state parse error: ${e.message}")
                 }
@@ -327,10 +336,14 @@ class GameStompClient(context: Context) : GameRealtimeClient {
 
     companion object {
         private const val TAG = "GameStompClient"
+        private const val PHASE_ROUND_FINISHED = "ROUND_FINISHED"
         private val SERVER_URL = SkyjoApiClient.WS_BASE_URL
         private const val PREF_GAME_ID = "game_id"
     }
 
     private fun ticketUrl(ticket: String): String =
         "$SERVER_URL?ticket=${URLEncoder.encode(ticket, "UTF-8")}"
+
+    private fun GameUpdateMessage.isRejoinable(): Boolean =
+        !gameOver && phase != PHASE_ROUND_FINISHED
 }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
@@ -13,8 +13,9 @@ import org.hildan.krossbow.stomp.StompSession
 import org.hildan.krossbow.stomp.sendText
 import org.hildan.krossbow.stomp.subscribeText
 import org.hildan.krossbow.websocket.okhttp.OkHttpWebSocketClient
+import java.net.URLEncoder
 
-class GameStompClient(context: Context) {
+class GameStompClient(context: Context) : GameRealtimeClient {
 
     private val prefs: SharedPreferences =
         context.getSharedPreferences("skyjo_prefs", Context.MODE_PRIVATE)
@@ -22,7 +23,8 @@ class GameStompClient(context: Context) {
     private val stompClient = StompClient(OkHttpWebSocketClient())
     private var session: StompSession? = null
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private var subscriptionJobs: List<Job> = emptyList()
+    private val subscriptionJobs = mutableListOf<Job>()
+    private val subscribedGameIds = mutableSetOf<String>()
 
     private val json = Json {
         ignoreUnknownKeys = true
@@ -30,27 +32,34 @@ class GameStompClient(context: Context) {
     }
 
     private val _lobbyState = MutableStateFlow<LobbyUpdateMessage?>(null)
-    val lobbyState: StateFlow<LobbyUpdateMessage?> = _lobbyState.asStateFlow()
+    override val lobbyState: StateFlow<LobbyUpdateMessage?> = _lobbyState.asStateFlow()
 
     private val _gameState = MutableStateFlow<GameUpdateMessage?>(null)
-    val gameState: StateFlow<GameUpdateMessage?> = _gameState.asStateFlow()
+    override val gameState: StateFlow<GameUpdateMessage?> = _gameState.asStateFlow()
 
     private val _actionCardResults = MutableSharedFlow<ActionCardResultMessage>(extraBufferCapacity = 1)
-    val actionCardResults: SharedFlow<ActionCardResultMessage> = _actionCardResults.asSharedFlow()
+    override val actionCardResults: SharedFlow<ActionCardResultMessage> = _actionCardResults.asSharedFlow()
+
+    private val _incomingInvites = MutableSharedFlow<at.aau.se2.skyjo.model.social.LobbyInviteDto>(extraBufferCapacity = 4)
+    override val incomingInvites: SharedFlow<at.aau.se2.skyjo.model.social.LobbyInviteDto> = _incomingInvites.asSharedFlow()
 
     private val _errorMessage = MutableSharedFlow<String>(extraBufferCapacity = 1)
-    val errorMessage: SharedFlow<String> = _errorMessage.asSharedFlow()
+    override val errorMessage: SharedFlow<String> = _errorMessage.asSharedFlow()
 
     private val _connectionError = MutableStateFlow<String?>(null)
-    val connectionError: StateFlow<String?> = _connectionError.asStateFlow()
+    override val connectionError: StateFlow<String?> = _connectionError.asStateFlow()
 
     private val _isConnected = MutableStateFlow(false)
-    val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
+    override val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
 
     private val _hasRejoinedGame = MutableStateFlow(false)
-    val hasRejoinedGame: StateFlow<Boolean> = _hasRejoinedGame.asStateFlow()
+    override val hasRejoinedGame: StateFlow<Boolean> = _hasRejoinedGame.asStateFlow()
 
-    suspend fun connect() {
+    override suspend fun connect() {
+        connect(ticket = null, lobbyJoinCode = null)
+    }
+
+    override suspend fun connect(ticket: String?, lobbyJoinCode: String?) {
         _hasRejoinedGame.value = false
         cancelSubscriptions()
         try {
@@ -58,28 +67,29 @@ class GameStompClient(context: Context) {
         } catch (_: Exception) {}
 
         try {
-            session = stompClient.connect(SERVER_URL)
+            session = stompClient.connect(ticket?.let(::ticketUrl) ?: SERVER_URL)
             _connectionError.value = null
             _isConnected.value = true
             Log.d(TAG, "Connected successfully")
 
-            // Subscriptions synchron aufbauen — alle sind aktiv bevor connect() zurückgibt,
-            // damit joinLobby danach keine Nachrichten verpasst
+            // Subscribe before returning so lobby actions cannot miss first updates.
             val s = session!!
-            val lobbyFlow       = s.subscribeText("/topic/lobby")
+            val lobbyFlow       = s.subscribeText(lobbyJoinCode?.let { "/topic/lobbies/$it" } ?: "/topic/lobby")
             val lobbyDirectFlow = s.subscribeText("/user/queue/lobby")
             val gameFlow        = s.subscribeText("/topic/game")
             val errorsFlow      = s.subscribeText("/user/queue/errors")
             val rejoinFlow      = s.subscribeText("/user/queue/gamestate")
             val actionCardResultsFlow = s.subscribeText("/user/queue/action-card-results")
+            val invitesFlow = s.subscribeText("/user/queue/invites")
 
-            subscriptionJobs = listOf(
+            subscriptionJobs += listOf(
                 scope.launch { collectLobby(lobbyFlow) },
                 scope.launch { collectLobbyDirect(lobbyDirectFlow) },
                 scope.launch { collectGame(gameFlow) },
                 scope.launch { collectErrors(errorsFlow) },
                 scope.launch { collectRejoinState(rejoinFlow) },
                 scope.launch { collectActionCardResults(actionCardResultsFlow) },
+                scope.launch { collectInvites(invitesFlow) },
             )
         } catch (e: Exception) {
             Log.e(TAG, "Connection error: ${e.message}")
@@ -90,7 +100,7 @@ class GameStompClient(context: Context) {
 
     private val retryDelays = listOf(1_000L, 3_000L, 9_000L)
 
-    suspend fun reconnect(playerName: String) {
+    override suspend fun reconnect(playerName: String) {
         val storedGameId = prefs.getString(PREF_GAME_ID, null)
         for (delay in retryDelays) {
             delay(delay)
@@ -105,7 +115,12 @@ class GameStompClient(context: Context) {
 
     private fun cancelSubscriptions() {
         subscriptionJobs.forEach { it.cancel() }
-        subscriptionJobs = emptyList()
+        subscriptionJobs.clear()
+        subscribedGameIds.clear()
+    }
+
+    override fun applyLobbyState(lobby: LobbyUpdateMessage) {
+        _lobbyState.value = lobby
     }
 
     private suspend fun collectLobby(flow: kotlinx.coroutines.flow.Flow<String>) {
@@ -145,6 +160,7 @@ class GameStompClient(context: Context) {
                 try {
                     val msg = json.decodeFromString<GameUpdateMessage>(jsonText)
                     msg.gameId?.let { prefs.edit().putString(PREF_GAME_ID, it).apply() }
+                    msg.gameId?.let { subscribeGameTopic(it) }
                     _gameState.value = msg
                 } catch (e: Exception) {
                     Log.e(TAG, "Game parse error: ${e.message}")
@@ -178,6 +194,8 @@ class GameStompClient(context: Context) {
             flow.collect { jsonText ->
                 try {
                     val msg = json.decodeFromString<GameUpdateMessage>(jsonText)
+                    msg.gameId?.let { prefs.edit().putString(PREF_GAME_ID, it).apply() }
+                    msg.gameId?.let { subscribeGameTopic(it) }
                     _gameState.value = msg
                     _hasRejoinedGame.value = true
                 } catch (e: Exception) {
@@ -205,7 +223,35 @@ class GameStompClient(context: Context) {
         }
     }
 
-    fun joinLobby(playerName: String, gameId: String? = null) {
+    private suspend fun collectInvites(flow: kotlinx.coroutines.flow.Flow<String>) {
+        try {
+            flow.collect { jsonText ->
+                try {
+                    _incomingInvites.tryEmit(json.decodeFromString(jsonText))
+                } catch (e: Exception) {
+                    Log.e(TAG, "Invite parse error: ${e.message}")
+                }
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Log.e(TAG, "Invite subscribe error: ${e.message}")
+        }
+    }
+
+    private fun subscribeGameTopic(gameId: String) {
+        val s = session ?: return
+        if (!subscribedGameIds.add(gameId)) return
+        subscriptionJobs += scope.launch {
+            runCatching {
+                collectGame(s.subscribeText("/topic/games/$gameId"))
+            }.onFailure { e ->
+                if (e is CancellationException) throw e
+                Log.e(TAG, "Game topic subscribe error: ${e.message}")
+            }
+        }
+    }
+
+    override fun joinLobby(playerName: String, gameId: String?) {
         scope.launch {
             try {
                 session?.sendText(
@@ -219,7 +265,7 @@ class GameStompClient(context: Context) {
         }
     }
 
-    fun leaveLobby() {
+    override fun leaveLobby() {
         scope.launch {
             try {
                 session?.sendText("/app/lobby.leave", "")
@@ -229,7 +275,7 @@ class GameStompClient(context: Context) {
         }
     }
 
-    fun startGame(maxRounds: Int, targetScore: Int) {
+    override fun startGame(maxRounds: Int, targetScore: Int) {
         scope.launch {
             try {
                 session?.sendText(
@@ -242,7 +288,7 @@ class GameStompClient(context: Context) {
         }
     }
 
-    fun sendAction(action: GameAction) {
+    override fun sendAction(action: GameAction) {
         scope.launch {
             try {
                 session?.sendText("/app/game.action", json.encodeToString(action))
@@ -252,7 +298,7 @@ class GameStompClient(context: Context) {
         }
     }
 
-    fun playActionCard(command: PlayActionCardCommand) {
+    override fun playActionCard(command: PlayActionCardCommand) {
         scope.launch {
             try {
                 session?.sendText("/app/game.action-card", json.encodeToString(command))
@@ -262,11 +308,11 @@ class GameStompClient(context: Context) {
         }
     }
 
-    fun clearStoredGame() {
+    override fun clearStoredGame() {
         prefs.edit().remove(PREF_GAME_ID).apply()
     }
 
-    fun disconnect() {
+    override fun disconnect() {
         cancelSubscriptions()
         scope.launch {
             try { session?.disconnect() } catch (_: Exception) {}
@@ -274,14 +320,17 @@ class GameStompClient(context: Context) {
         _isConnected.value = false
     }
 
-    fun close() {
+    override fun close() {
         disconnect()
         scope.cancel()
     }
 
     companion object {
         private const val TAG = "GameStompClient"
-        private const val SERVER_URL = "ws://se2-demo.aau.at:53209/ws"
+        private const val SERVER_URL = SkyjoApiClient.WS_BASE_URL
         private const val PREF_GAME_ID = "game_id"
     }
+
+    private fun ticketUrl(ticket: String): String =
+        "$SERVER_URL?ticket=${URLEncoder.encode(ticket, "UTF-8")}"
 }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
@@ -110,7 +110,7 @@ class GameStompClient(context: Context) : GameRealtimeClient {
                 return
             }
         }
-        _connectionError.value = "Verbindung getrennt"
+        _connectionError.value = "Connection lost"
     }
 
     private fun cancelSubscriptions() {

--- a/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
@@ -327,7 +327,7 @@ class GameStompClient(context: Context) : GameRealtimeClient {
 
     companion object {
         private const val TAG = "GameStompClient"
-        private const val SERVER_URL = SkyjoApiClient.WS_BASE_URL
+        private val SERVER_URL = SkyjoApiClient.WS_BASE_URL
         private const val PREF_GAME_ID = "game_id"
     }
 

--- a/app/src/main/kotlin/at/aau/se2/skyjo/network/SkyjoApi.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/network/SkyjoApi.kt
@@ -1,0 +1,40 @@
+package at.aau.se2.skyjo.network
+
+import at.aau.se2.skyjo.model.auth.AuthResponse
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.auth.WsTicketResponse
+import at.aau.se2.skyjo.model.lobby.LobbySummaryResponse
+import at.aau.se2.skyjo.model.social.FriendDto
+import at.aau.se2.skyjo.model.social.FriendRequestDto
+import at.aau.se2.skyjo.model.social.FriendRequestsResponse
+import at.aau.se2.skyjo.model.social.LobbyInviteDto
+import at.aau.se2.skyjo.model.social.SocialUserDto
+import at.aau.se2.skyjo.model.stats.LeaderboardEntryDto
+import at.aau.se2.skyjo.model.stats.PlayerStatsDto
+
+interface SkyjoApi {
+    suspend fun register(username: String, password: String): AuthResponse = unsupported()
+    suspend fun login(username: String, password: String): AuthResponse = unsupported()
+    suspend fun me(): AuthUserDto = unsupported()
+    suspend fun logout(): Unit = unsupported()
+    suspend fun createWebSocketTicket(): WsTicketResponse = unsupported()
+    suspend fun myStats(): PlayerStatsDto = unsupported()
+    suspend fun leaderboard(limit: Int = 50): List<LeaderboardEntryDto> = unsupported()
+    suspend fun createLobby(): LobbySummaryResponse = unsupported()
+    suspend fun joinLobby(joinCode: String): LobbySummaryResponse = unsupported()
+    suspend fun currentLobby(): LobbySummaryResponse? = unsupported()
+    suspend fun leaveLobby(lobbyId: String): LobbySummaryResponse = unsupported()
+    suspend fun searchUsers(query: String): List<SocialUserDto> = unsupported()
+    suspend fun friends(): List<FriendDto> = unsupported()
+    suspend fun friendRequests(): FriendRequestsResponse = unsupported()
+    suspend fun sendFriendRequest(toUserId: String): FriendRequestDto = unsupported()
+    suspend fun acceptFriendRequest(requestId: String): FriendRequestDto = unsupported()
+    suspend fun declineFriendRequest(requestId: String): FriendRequestDto = unsupported()
+    suspend fun lobbyInvites(): List<LobbyInviteDto> = unsupported()
+    suspend fun sendLobbyInvite(lobbyId: String, toUserId: String): LobbyInviteDto = unsupported()
+    suspend fun acceptLobbyInvite(inviteId: String): LobbyInviteDto = unsupported()
+    suspend fun declineLobbyInvite(inviteId: String): LobbyInviteDto = unsupported()
+
+    private fun unsupported(): Nothing =
+        throw UnsupportedOperationException("SkyjoApi method not implemented")
+}

--- a/app/src/main/kotlin/at/aau/se2/skyjo/network/SkyjoApiClient.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/network/SkyjoApiClient.kt
@@ -1,5 +1,6 @@
 package at.aau.se2.skyjo.network
 
+import at.aau.se2.skyjo.BuildConfig
 import at.aau.se2.skyjo.model.auth.AuthResponse
 import at.aau.se2.skyjo.model.auth.AuthUserDto
 import at.aau.se2.skyjo.model.auth.ErrorResponse
@@ -156,8 +157,8 @@ class SkyjoApiClient(
     }
 
     companion object {
-        const val HTTP_BASE_URL = "http://se2-demo.aau.at:53209"
-        const val WS_BASE_URL = "ws://se2-demo.aau.at:53209/ws"
+        val HTTP_BASE_URL: String = BuildConfig.HTTP_BASE_URL
+        val WS_BASE_URL: String = BuildConfig.WS_BASE_URL
         private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
     }
 

--- a/app/src/main/kotlin/at/aau/se2/skyjo/network/SkyjoApiClient.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/network/SkyjoApiClient.kt
@@ -1,0 +1,166 @@
+package at.aau.se2.skyjo.network
+
+import at.aau.se2.skyjo.model.auth.AuthResponse
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.auth.ErrorResponse
+import at.aau.se2.skyjo.model.auth.LoginRequest
+import at.aau.se2.skyjo.model.auth.RegisterRequest
+import at.aau.se2.skyjo.model.auth.WsTicketResponse
+import at.aau.se2.skyjo.model.lobby.LobbySummaryResponse
+import at.aau.se2.skyjo.model.social.FriendDto
+import at.aau.se2.skyjo.model.social.FriendRequestsResponse
+import at.aau.se2.skyjo.model.social.LobbyInviteDto
+import at.aau.se2.skyjo.model.social.LobbyInviteRequest
+import at.aau.se2.skyjo.model.social.SendFriendRequestRequest
+import at.aau.se2.skyjo.model.social.SocialUserDto
+import at.aau.se2.skyjo.model.stats.LeaderboardEntryDto
+import at.aau.se2.skyjo.model.stats.PlayerStatsDto
+import at.aau.se2.skyjo.session.SessionStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.net.URLEncoder
+
+class ApiException(message: String, val statusCode: Int? = null) : Exception(message)
+
+class SkyjoApiClient(
+    private val sessionStore: SessionStore,
+    private val client: OkHttpClient = OkHttpClient(),
+    private val baseUrl: String = HTTP_BASE_URL,
+) : SkyjoApi {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    override suspend fun register(username: String, password: String): AuthResponse =
+        post("/api/auth/register", RegisterRequest(username, password))
+
+    override suspend fun login(username: String, password: String): AuthResponse =
+        post("/api/auth/login", LoginRequest(username, password))
+
+    override suspend fun me(): AuthUserDto =
+        get("/api/auth/me")
+
+    override suspend fun logout() {
+        request<Unit>("POST", "/api/auth/logout")
+    }
+
+    override suspend fun createWebSocketTicket(): WsTicketResponse =
+        postEmpty("/api/auth/ws-ticket")
+
+    override suspend fun myStats(): PlayerStatsDto =
+        get("/api/stats/me")
+
+    override suspend fun leaderboard(limit: Int): List<LeaderboardEntryDto> =
+        get("/api/leaderboard?limit=$limit")
+
+    override suspend fun createLobby(): LobbySummaryResponse =
+        postEmpty("/api/lobbies")
+
+    override suspend fun joinLobby(joinCode: String): LobbySummaryResponse =
+        postEmpty("/api/lobbies/${encode(joinCode.trim())}/join")
+
+    override suspend fun currentLobby(): LobbySummaryResponse? =
+        request("GET", "/api/lobbies/current", allowNoContent = true)
+
+    override suspend fun leaveLobby(lobbyId: String): LobbySummaryResponse =
+        postEmpty("/api/lobbies/${encode(lobbyId)}/leave")
+
+    override suspend fun searchUsers(query: String): List<SocialUserDto> =
+        get("/api/users/search?query=${encode(query.trim())}")
+
+    override suspend fun friends(): List<FriendDto> =
+        get("/api/friends")
+
+    override suspend fun friendRequests(): FriendRequestsResponse =
+        get("/api/friends/requests")
+
+    override suspend fun sendFriendRequest(toUserId: String) =
+        post<SendFriendRequestRequest, at.aau.se2.skyjo.model.social.FriendRequestDto>(
+            "/api/friends/requests",
+            SendFriendRequestRequest(toUserId),
+        )
+
+    override suspend fun acceptFriendRequest(requestId: String) =
+        postEmpty<at.aau.se2.skyjo.model.social.FriendRequestDto>("/api/friends/requests/${encode(requestId)}/accept")
+
+    override suspend fun declineFriendRequest(requestId: String) =
+        postEmpty<at.aau.se2.skyjo.model.social.FriendRequestDto>("/api/friends/requests/${encode(requestId)}/decline")
+
+    override suspend fun lobbyInvites(): List<LobbyInviteDto> =
+        get("/api/lobbies/invites")
+
+    override suspend fun sendLobbyInvite(lobbyId: String, toUserId: String): LobbyInviteDto =
+        post("/api/lobbies/${encode(lobbyId)}/invites", LobbyInviteRequest(toUserId))
+
+    override suspend fun acceptLobbyInvite(inviteId: String): LobbyInviteDto =
+        postEmpty("/api/lobbies/invites/${encode(inviteId)}/accept")
+
+    override suspend fun declineLobbyInvite(inviteId: String): LobbyInviteDto =
+        postEmpty("/api/lobbies/invites/${encode(inviteId)}/decline")
+
+    private suspend inline fun <reified T> get(path: String): T =
+        request("GET", path) ?: throw ApiException("Leere Antwort")
+
+    private suspend inline fun <reified RequestBody : Any, reified ResponseBody> post(
+        path: String,
+        body: RequestBody,
+    ): ResponseBody =
+        request("POST", path, json.encodeToString(body)) ?: throw ApiException("Leere Antwort")
+
+    private suspend inline fun <reified T> postEmpty(path: String): T =
+        request("POST", path) ?: throw ApiException("Leere Antwort")
+
+    private suspend inline fun <reified T> request(
+        method: String,
+        path: String,
+        bodyJson: String? = null,
+        allowNoContent: Boolean = false,
+    ): T? = withContext(Dispatchers.IO) {
+        val requestBuilder = Request.Builder()
+            .url(baseUrl.trimEnd('/') + path)
+        sessionStore.getToken()?.let { token ->
+            requestBuilder.header("Authorization", "Bearer $token")
+        }
+        val body = bodyJson?.toRequestBody(JSON_MEDIA_TYPE)
+        when (method) {
+            "GET" -> requestBuilder.get()
+            "POST" -> requestBuilder.post(body ?: ByteArray(0).toRequestBody(JSON_MEDIA_TYPE))
+            else -> error("Unsupported method $method")
+        }
+
+        client.newCall(requestBuilder.build()).execute().use { response ->
+            if (response.code == 204 && allowNoContent) {
+                return@withContext null
+            }
+            val responseBody = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                val message = runCatching {
+                    json.decodeFromString<ErrorResponse>(responseBody).message
+                }.getOrElse { response.message.ifBlank { "Request failed" } }
+                throw ApiException(message, response.code)
+            }
+            if (T::class == Unit::class) {
+                @Suppress("UNCHECKED_CAST")
+                return@withContext Unit as T
+            }
+            json.decodeFromString<T>(responseBody)
+        }
+    }
+
+    companion object {
+        const val HTTP_BASE_URL = "http://se2-demo.aau.at:53209"
+        const val WS_BASE_URL = "ws://se2-demo.aau.at:53209/ws"
+        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+    }
+
+    private fun encode(value: String): String =
+        URLEncoder.encode(value, "UTF-8")
+}

--- a/app/src/main/kotlin/at/aau/se2/skyjo/network/SkyjoApiClient.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/network/SkyjoApiClient.kt
@@ -3,7 +3,6 @@ package at.aau.se2.skyjo.network
 import at.aau.se2.skyjo.BuildConfig
 import at.aau.se2.skyjo.model.auth.AuthResponse
 import at.aau.se2.skyjo.model.auth.AuthUserDto
-import at.aau.se2.skyjo.model.auth.ErrorResponse
 import at.aau.se2.skyjo.model.auth.LoginRequest
 import at.aau.se2.skyjo.model.auth.RegisterRequest
 import at.aau.se2.skyjo.model.auth.WsTicketResponse
@@ -28,6 +27,13 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import java.net.URLEncoder
 
 class ApiException(message: String, val statusCode: Int? = null) : Exception(message)
+
+@kotlinx.serialization.Serializable
+private data class ServerErrorResponse(
+    val message: String? = null,
+    val error: String? = null,
+    val status: Int? = null,
+)
 
 class SkyjoApiClient(
     private val sessionStore: SessionStore,
@@ -144,8 +150,9 @@ class SkyjoApiClient(
             val responseBody = response.body?.string().orEmpty()
             if (!response.isSuccessful) {
                 val message = runCatching {
-                    json.decodeFromString<ErrorResponse>(responseBody).message
-                }.getOrElse { response.message.ifBlank { "Request failed" } }
+                    json.decodeFromString<ServerErrorResponse>(responseBody)
+                        .let { it.message ?: it.error ?: "HTTP ${response.code}" }
+                }.getOrElse { "HTTP ${response.code}" }
                 throw ApiException(message, response.code)
             }
             if (T::class == Unit::class) {

--- a/app/src/main/kotlin/at/aau/se2/skyjo/session/EncryptedSessionStore.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/session/EncryptedSessionStore.kt
@@ -1,0 +1,36 @@
+package at.aau.se2.skyjo.session
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+class EncryptedSessionStore(context: Context) : SessionStore {
+
+    private val appContext = context.applicationContext
+    private val masterKey = MasterKey.Builder(appContext)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+    private val preferences = EncryptedSharedPreferences.create(
+        appContext,
+        PREFS_NAME,
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+    )
+
+    override fun saveToken(token: String) {
+        preferences.edit().putString(KEY_TOKEN, token).apply()
+    }
+
+    override fun getToken(): String? =
+        preferences.getString(KEY_TOKEN, null)
+
+    override fun clearToken() {
+        preferences.edit().remove(KEY_TOKEN).apply()
+    }
+
+    private companion object {
+        const val PREFS_NAME = "skyjo_secure_session"
+        const val KEY_TOKEN = "session_token"
+    }
+}

--- a/app/src/main/kotlin/at/aau/se2/skyjo/session/SessionStore.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/session/SessionStore.kt
@@ -1,0 +1,7 @@
+package at.aau.se2.skyjo.session
+
+interface SessionStore {
+    fun saveToken(token: String)
+    fun getToken(): String?
+    fun clearToken()
+}

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/components/SkyjoScaffold.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/components/SkyjoScaffold.kt
@@ -104,6 +104,7 @@ private data class NavTab(
 private val navTabs = listOf(
     NavTab(AppDestination.Start, Icons.Default.PlayArrow, "Play"),
     NavTab(AppDestination.Friends, Icons.Default.Group, "Friends"),
+    NavTab(AppDestination.Leaderboard, Icons.Default.EmojiEvents, "Board"),
     NavTab(AppDestination.Settings, Icons.Default.Settings, "Settings"),
 )
 
@@ -178,7 +179,7 @@ private data class DrawerItem(
 private val drawerItems = listOf(
     DrawerItem(Icons.Default.Settings, "Settings", AppDestination.Settings),
     DrawerItem(Icons.Default.Style, "Card Sleeves"),
-    DrawerItem(Icons.Default.EmojiEvents, "Leaderboard"),
+    DrawerItem(Icons.Default.EmojiEvents, "Leaderboard", AppDestination.Leaderboard),
     DrawerItem(Icons.Default.History, "Match History"),
     DrawerItem(Icons.Default.Help, "How to Play"),
 )
@@ -204,7 +205,7 @@ fun SkyjoDrawerContent(
             ) {
                 Box(contentAlignment = Alignment.Center) {
                     Text(
-                        text = "A",
+                        text = "S",
                         style = MaterialTheme.typography.titleLarge,
                         color = PrimaryGreen,
                         fontWeight = FontWeight.ExtraBold,
@@ -214,12 +215,12 @@ fun SkyjoDrawerContent(
             Spacer(modifier = Modifier.width(14.dp))
             Column {
                 Text(
-                    text = "AcePlayer",
+                    text = "Skyjo",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                 )
                 Text(
-                    text = "Pro Tier",
+                    text = "Account aktiv",
                     style = MaterialTheme.typography.bodySmall,
                     color = PrimaryGreen,
                 )

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/components/SkyjoScaffold.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/components/SkyjoScaffold.kt
@@ -220,7 +220,7 @@ fun SkyjoDrawerContent(
                     fontWeight = FontWeight.Bold,
                 )
                 Text(
-                    text = "Account aktiv",
+                    text = "Account active",
                     style = MaterialTheme.typography.bodySmall,
                     color = PrimaryGreen,
                 )

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppDestinations.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppDestinations.kt
@@ -1,9 +1,11 @@
 package at.aau.se2.skyjo.ui.navigation
 
 sealed class AppDestination(val route: String) {
+    object Auth : AppDestination("auth")
     object Start : AppDestination("start")
     object Lobby : AppDestination("lobby")
     object Game : AppDestination("game")
     object Friends : AppDestination("friends")
+    object Leaderboard : AppDestination("leaderboard")
     object Settings : AppDestination("settings")
 }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
@@ -23,18 +23,29 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import at.aau.se2.skyjo.model.ActionCardResultMessage
+import at.aau.se2.skyjo.ui.screens.auth.AuthScreen
 import at.aau.se2.skyjo.ui.screens.friends.FriendsScreen
 import at.aau.se2.skyjo.ui.screens.game.GameScreen
+import at.aau.se2.skyjo.ui.screens.leaderboard.LeaderboardScreen
 import at.aau.se2.skyjo.ui.screens.lobby.LobbyScreen
 import at.aau.se2.skyjo.ui.screens.settings.SettingsScreen
 import at.aau.se2.skyjo.ui.screens.start.StartScreen
+import at.aau.se2.skyjo.viewmodel.AuthViewModel
+import at.aau.se2.skyjo.viewmodel.AuthUiState
+import at.aau.se2.skyjo.viewmodel.FriendsUiState
+import at.aau.se2.skyjo.viewmodel.FriendsViewModel
 import at.aau.se2.skyjo.viewmodel.GameViewModel
+import at.aau.se2.skyjo.viewmodel.LeaderboardUiState
+import at.aau.se2.skyjo.viewmodel.LeaderboardViewModel
 
 @Composable
 fun AppNavHost(
     navController: NavHostController,
     modifier: Modifier = Modifier,
+    authViewModel: AuthViewModel? = null,
     gameViewModel: GameViewModel,
+    friendsViewModel: FriendsViewModel? = null,
+    leaderboardViewModel: LeaderboardViewModel? = null,
 ) {
     val navigateMain: (AppDestination) -> Unit = { dest ->
         navController.navigate(dest.route) {
@@ -47,6 +58,13 @@ fun AppNavHost(
     val isConnected by gameViewModel.isConnected.collectAsState()
     val myPlayerName by gameViewModel.myPlayerName.collectAsState()
     val hasRejoinedGame by gameViewModel.hasRejoinedGame.collectAsState()
+    val fallbackAuthState = remember { mutableStateOf(AuthUiState(isCheckingSession = false, isAuthenticated = true)) }
+    val fallbackFriendsState = remember { mutableStateOf(FriendsUiState()) }
+    val fallbackLeaderboardState = remember { mutableStateOf(LeaderboardUiState()) }
+    val authState = authViewModel?.state?.collectAsState()?.value ?: fallbackAuthState.value
+    val homeStats by gameViewModel.homeStats.collectAsState()
+    val friendsState = friendsViewModel?.state?.collectAsState()?.value ?: fallbackFriendsState.value
+    val leaderboardState = leaderboardViewModel?.state?.collectAsState()?.value ?: fallbackLeaderboardState.value
 
     LaunchedEffect(hasRejoinedGame) {
         if (hasRejoinedGame && navController.currentDestination?.route != AppDestination.Game.route) {
@@ -56,24 +74,73 @@ fun AppNavHost(
         }
     }
 
+    LaunchedEffect(Unit) {
+        gameViewModel.incomingInvites.collect { invite ->
+            friendsViewModel?.addLobbyInvite(invite)
+        }
+    }
+
     Box(modifier = modifier.fillMaxSize()) {
         NavHost(
             navController = navController,
-            startDestination = AppDestination.Start.route,
+            startDestination = AppDestination.Auth.route,
             modifier = Modifier.fillMaxSize(),
         ) {
+            composable(AppDestination.Auth.route) {
+                LaunchedEffect(authState.isAuthenticated) {
+                    if (authState.isAuthenticated) {
+                        authState.user?.username?.let(gameViewModel::setAuthenticatedUsername)
+                        navController.navigate(AppDestination.Start.route) {
+                            popUpTo(AppDestination.Auth.route) { inclusive = true }
+                        }
+                    }
+                }
+                AuthScreen(
+                    state = authState,
+                    onUsernameChange = { authViewModel?.updateUsername(it) },
+                    onPasswordChange = { authViewModel?.updatePassword(it) },
+                    onSubmit = { authViewModel?.submit() },
+                    onToggleMode = { authViewModel?.toggleMode() },
+                )
+            }
+
             composable(AppDestination.Start.route) {
+                val username = authState.user?.username.orEmpty()
+                LaunchedEffect(username) {
+                    if (username.isNotBlank()) {
+                        gameViewModel.setAuthenticatedUsername(username)
+                        gameViewModel.refreshHomeStats()
+                    }
+                }
                 StartScreen(
                     onPlayClicked = { playerName ->
                         gameViewModel.connect(playerName)
                         navController.navigate(AppDestination.Lobby.route)
                     },
                     onNavigate = navigateMain,
+                    username = username,
+                    stats = homeStats,
+                    onCreateLobby = {
+                        gameViewModel.createLobby(username)
+                        navController.navigate(AppDestination.Lobby.route)
+                    },
+                    onJoinLobby = { code ->
+                        gameViewModel.joinLobbyByCode(username, code)
+                        navController.navigate(AppDestination.Lobby.route)
+                    },
+                    onLogout = {
+                        authViewModel?.logout()
+                        gameViewModel.leaveLobby()
+                        navController.navigate(AppDestination.Auth.route) {
+                            popUpTo(AppDestination.Start.route) { inclusive = true }
+                        }
+                    },
                 )
             }
 
             composable(AppDestination.Lobby.route) {
                 val lobbyState by gameViewModel.lobbyState.collectAsState()
+                val lobbyError by gameViewModel.lobbyError.collectAsState()
                 val isHost by gameViewModel.isHost.collectAsState()
 
                 LaunchedEffect(lobbyState?.status) {
@@ -88,6 +155,8 @@ fun AppNavHost(
                     players = lobbyState?.players ?: emptyList(),
                     maxPlayers = lobbyState?.maxPlayers ?: 6,
                     isHost = isHost,
+                    joinCode = lobbyState?.joinCode,
+                    errorMessage = lobbyError,
                     onStartGame = { maxRounds ->
                         gameViewModel.startGame(maxRounds = maxRounds)
                     },
@@ -138,7 +207,36 @@ fun AppNavHost(
             }
 
             composable(AppDestination.Friends.route) {
-                FriendsScreen(onNavigate = navigateMain)
+                LaunchedEffect(Unit) { friendsViewModel?.refresh() }
+                FriendsScreen(
+                    onNavigate = navigateMain,
+                    friends = friendsState.friends,
+                    incomingRequests = friendsState.incomingRequests,
+                    lobbyInvites = friendsState.lobbyInvites,
+                    searchResults = friendsState.searchResults,
+                    query = friendsState.query,
+                    activeLobbyId = gameViewModel.lobbyState.collectAsState().value?.lobbyId,
+                    onQueryChange = { friendsViewModel?.updateSearch(it) },
+                    onSendRequest = { friendsViewModel?.sendFriendRequest(it) },
+                    onAcceptRequest = { friendsViewModel?.acceptRequest(it) },
+                    onDeclineRequest = { friendsViewModel?.declineRequest(it) },
+                    onInviteFriend = { friendUserId ->
+                        friendsViewModel?.inviteFriend(gameViewModel.lobbyState.value?.lobbyId, friendUserId)
+                    },
+                    onAcceptInvite = { inviteId ->
+                        friendsViewModel?.removeLobbyInvite(inviteId)
+                        gameViewModel.acceptLobbyInvite(username = authState.user?.username.orEmpty(), inviteId = inviteId)
+                        navController.navigate(AppDestination.Lobby.route)
+                    },
+                    onDeclineInvite = { inviteId ->
+                        friendsViewModel?.declineLobbyInvite(inviteId)
+                    },
+                )
+            }
+
+            composable(AppDestination.Leaderboard.route) {
+                LaunchedEffect(Unit) { leaderboardViewModel?.refresh() }
+                LeaderboardScreen(onNavigate = navigateMain, entries = leaderboardState.entries)
             }
 
             composable(AppDestination.Settings.route) {
@@ -148,7 +246,7 @@ fun AppNavHost(
 
         if (!isConnected && myPlayerName.isNotEmpty()) {
             Text(
-                text = "Verbindung unterbrochen, versuche erneut…",
+                text = "Verbindung unterbrochen, versuche erneut...",
                 style = MaterialTheme.typography.labelMedium,
                 color = Color.White,
                 textAlign = TextAlign.Center,

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
@@ -58,6 +58,8 @@ fun AppNavHost(
     val isConnected by gameViewModel.isConnected.collectAsState()
     val myPlayerName by gameViewModel.myPlayerName.collectAsState()
     val hasRejoinedGame by gameViewModel.hasRejoinedGame.collectAsState()
+    val currentLobbyState by gameViewModel.lobbyState.collectAsState()
+    val currentGameState by gameViewModel.gameState.collectAsState()
     val fallbackAuthState = remember { mutableStateOf(AuthUiState(isCheckingSession = false, isAuthenticated = true)) }
     val fallbackFriendsState = remember { mutableStateOf(FriendsUiState()) }
     val fallbackLeaderboardState = remember { mutableStateOf(LeaderboardUiState()) }
@@ -244,7 +246,7 @@ fun AppNavHost(
             }
         }
 
-        if (!isConnected && myPlayerName.isNotEmpty()) {
+        if (!isConnected && myPlayerName.isNotEmpty() && (currentLobbyState != null || currentGameState != null)) {
             Text(
                 text = "Verbindung unterbrochen, versuche erneut...",
                 style = MaterialTheme.typography.labelMedium,

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
@@ -248,7 +248,7 @@ fun AppNavHost(
 
         if (!isConnected && myPlayerName.isNotEmpty() && (currentLobbyState != null || currentGameState != null)) {
             Text(
-                text = "Verbindung unterbrochen, versuche erneut...",
+                text = "Connection interrupted, retrying...",
                 style = MaterialTheme.typography.labelMedium,
                 color = Color.White,
                 textAlign = TextAlign.Center,

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/auth/AuthScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/auth/AuthScreen.kt
@@ -1,0 +1,112 @@
+package at.aau.se2.skyjo.ui.screens.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import at.aau.se2.skyjo.viewmodel.AuthUiState
+import at.aau.se2.skyjo.ui.components.PrimaryButton
+import at.aau.se2.skyjo.ui.components.SkyjoCard
+import at.aau.se2.skyjo.ui.theme.PrimaryGreen
+
+@Composable
+fun AuthScreen(
+    state: AuthUiState,
+    onUsernameChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+    onToggleMode: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "Skyjo",
+            style = MaterialTheme.typography.displayMedium,
+            color = PrimaryGreen,
+            fontWeight = FontWeight.ExtraBold,
+        )
+        Text(
+            text = if (state.isRegisterMode) "Account erstellen" else "Einloggen",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+
+        SkyjoCard {
+            if (state.isCheckingSession) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    CircularProgressIndicator()
+                }
+                return@SkyjoCard
+            }
+
+            OutlinedTextField(
+                value = state.username,
+                onValueChange = onUsernameChange,
+                label = { Text("Username") },
+                singleLine = true,
+                enabled = !state.isSubmitting,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = state.password,
+                onValueChange = onPasswordChange,
+                label = { Text("Passwort") },
+                visualTransformation = PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                singleLine = true,
+                enabled = !state.isSubmitting,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            state.errorMessage?.let { message ->
+                Spacer(modifier = Modifier.height(10.dp))
+                Text(
+                    text = message,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            PrimaryButton(
+                text = if (state.isRegisterMode) "REGISTRIEREN" else "LOGIN",
+                onClick = onSubmit,
+                enabled = !state.isSubmitting,
+            )
+            TextButton(
+                onClick = onToggleMode,
+                enabled = !state.isSubmitting,
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+            ) {
+                Text(if (state.isRegisterMode) "Ich habe schon einen Account" else "Neuen Account erstellen")
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/auth/AuthScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/auth/AuthScreen.kt
@@ -48,7 +48,7 @@ fun AuthScreen(
             fontWeight = FontWeight.ExtraBold,
         )
         Text(
-            text = if (state.isRegisterMode) "Account erstellen" else "Einloggen",
+            text = if (state.isRegisterMode) "Create account" else "Log in",
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onBackground,
         )
@@ -79,7 +79,7 @@ fun AuthScreen(
             OutlinedTextField(
                 value = state.password,
                 onValueChange = onPasswordChange,
-                label = { Text("Passwort") },
+                label = { Text("Password") },
                 visualTransformation = PasswordVisualTransformation(),
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
                 singleLine = true,
@@ -96,7 +96,7 @@ fun AuthScreen(
             }
             Spacer(modifier = Modifier.height(16.dp))
             PrimaryButton(
-                text = if (state.isRegisterMode) "REGISTRIEREN" else "LOGIN",
+                text = if (state.isRegisterMode) "REGISTER" else "LOGIN",
                 onClick = onSubmit,
                 enabled = !state.isSubmitting,
             )
@@ -105,7 +105,7 @@ fun AuthScreen(
                 enabled = !state.isSubmitting,
                 modifier = Modifier.align(Alignment.CenterHorizontally),
             ) {
-                Text(if (state.isRegisterMode) "Ich habe schon einen Account" else "Neuen Account erstellen")
+                Text(if (state.isRegisterMode) "I already have an account" else "Create a new account")
             }
         }
     }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/friends/FriendsScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/friends/FriendsScreen.kt
@@ -2,13 +2,13 @@ package at.aau.se2.skyjo.ui.screens.friends
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -17,55 +17,46 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import at.aau.se2.skyjo.model.social.FriendDto
+import at.aau.se2.skyjo.model.social.FriendRequestDto
+import at.aau.se2.skyjo.model.social.LobbyInviteDto
+import at.aau.se2.skyjo.model.social.RelationshipStatus
+import at.aau.se2.skyjo.model.social.SocialUserDto
 import at.aau.se2.skyjo.ui.components.AvatarBadge
-import at.aau.se2.skyjo.ui.components.BadgeChip
 import at.aau.se2.skyjo.ui.components.SkyjoCard
 import at.aau.se2.skyjo.ui.components.SkyjoDrawerScaffold
 import at.aau.se2.skyjo.ui.navigation.AppDestination
-import at.aau.se2.skyjo.ui.theme.GoldSurface
-import at.aau.se2.skyjo.ui.theme.GoldYellow
 import at.aau.se2.skyjo.ui.theme.MintGreen
 import at.aau.se2.skyjo.ui.theme.MutedText
 import at.aau.se2.skyjo.ui.theme.OnlineGreen
 import at.aau.se2.skyjo.ui.theme.PrimaryGreen
 import at.aau.se2.skyjo.ui.theme.SkyjoTheme
 
-private data class Friend(
-    val name: String,
-    val status: String,
-    val isOnline: Boolean,
-    val level: Int,
-)
-
-private val onlineFriends = listOf(
-    Friend("KiraBlaze", "In Lobby", isOnline = true, level = 38),
-    Friend("MaxStorm", "Playing", isOnline = true, level = 21),
-    Friend("RiverDawn", "Available", isOnline = true, level = 55),
-)
-
-private val suggestedFriends = listOf(
-    Friend("TideWatcher", "Level 14", isOnline = false, level = 14),
-    Friend("SkyRunner", "Level 29", isOnline = false, level = 29),
-)
-
 @Composable
 fun FriendsScreen(
     onNavigate: (AppDestination) -> Unit,
     modifier: Modifier = Modifier,
+    friends: List<FriendDto> = emptyList(),
+    incomingRequests: List<FriendRequestDto> = emptyList(),
+    lobbyInvites: List<LobbyInviteDto> = emptyList(),
+    searchResults: List<SocialUserDto> = emptyList(),
+    query: String = "",
+    activeLobbyId: String? = null,
+    onQueryChange: (String) -> Unit = {},
+    onSendRequest: (String) -> Unit = {},
+    onAcceptRequest: (String) -> Unit = {},
+    onDeclineRequest: (String) -> Unit = {},
+    onInviteFriend: (String) -> Unit = {},
+    onAcceptInvite: (String) -> Unit = {},
+    onDeclineInvite: (String) -> Unit = {},
 ) {
     SkyjoDrawerScaffold(
         currentDestination = AppDestination.Friends,
@@ -78,190 +69,138 @@ fun FriendsScreen(
                 .padding(paddingValues)
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 20.dp, vertical = 24.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp),
+            verticalArrangement = Arrangement.spacedBy(18.dp),
         ) {
-            // Title
-            Text(
-                text = "Friends",
-                style = MaterialTheme.typography.headlineLarge,
-                color = MaterialTheme.colorScheme.onBackground,
-            )
-
-            // Search bar
-            var query by remember { mutableStateOf("") }
+            Text("Friends", style = MaterialTheme.typography.headlineLarge, fontWeight = FontWeight.Bold)
             OutlinedTextField(
                 value = query,
-                onValueChange = { query = it },
-                placeholder = { Text("Search players…", color = MutedText) },
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Default.Search,
-                        contentDescription = "Search",
-                        tint = MutedText,
-                    )
-                },
+                onValueChange = onQueryChange,
+                placeholder = { Text("User suchen") },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = "Search") },
                 singleLine = true,
-                shape = MaterialTheme.shapes.extraLarge,
-                colors = OutlinedTextFieldDefaults.colors(
-                    unfocusedBorderColor = MaterialTheme.colorScheme.outline,
-                    focusedBorderColor = PrimaryGreen,
-                ),
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            // Online friends
-            SectionHeader(
-                title = "Online Friends",
-                count = onlineFriends.size,
-                indicatorColor = OnlineGreen,
-            )
-            SkyjoCard {
-                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                    onlineFriends.forEachIndexed { index, friend ->
-                        FriendRow(friend = friend, showInvite = true)
-                        if (index < onlineFriends.lastIndex) {
-                            androidx.compose.material3.HorizontalDivider(
-                                color = MaterialTheme.colorScheme.outline,
-                            )
-                        }
+            if (searchResults.isNotEmpty()) {
+                SectionCard(title = "Suche") {
+                    searchResults.forEach { user ->
+                        SearchRow(user = user, onSendRequest = onSendRequest)
                     }
                 }
             }
 
-            // Suggested friends
-            SectionHeader(title = "Suggested Friends", count = null)
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                suggestedFriends.forEach { friend ->
-                    SuggestedFriendCard(friend = friend, modifier = Modifier.weight(1f))
+            if (incomingRequests.isNotEmpty()) {
+                SectionCard(title = "Anfragen") {
+                    incomingRequests.forEach { request ->
+                        RequestRow(request, onAcceptRequest, onDeclineRequest)
+                    }
                 }
             }
 
-            Spacer(modifier = Modifier.height(8.dp))
+            if (lobbyInvites.isNotEmpty()) {
+                SectionCard(title = "Lobby Einladungen") {
+                    lobbyInvites.forEach { invite ->
+                        InviteRow(invite, onAcceptInvite, onDeclineInvite)
+                    }
+                }
+            }
+
+            SectionCard(title = "Freunde") {
+                if (friends.isEmpty()) {
+                    Text("Noch keine Freunde", color = MutedText)
+                } else {
+                    friends.forEach { friend ->
+                        FriendRow(friend, showInvite = activeLobbyId != null, onInviteFriend = onInviteFriend)
+                    }
+                }
+            }
         }
     }
 }
 
 @Composable
-private fun SectionHeader(
-    title: String,
-    count: Int?,
-    indicatorColor: androidx.compose.ui.graphics.Color? = null,
-) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        if (indicatorColor != null) {
-            Surface(
-                shape = MaterialTheme.shapes.extraLarge,
-                color = indicatorColor,
-                modifier = Modifier.size(8.dp),
-            ) {}
-            Spacer(modifier = Modifier.width(6.dp))
-        }
-        Text(
-            text = if (count != null) "$title ($count)" else title,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onBackground,
-        )
+private fun SectionCard(title: String, content: @Composable ColumnScope.() -> Unit) {
+    SkyjoCard {
+        Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Spacer(modifier = Modifier.height(10.dp))
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp), content = content)
     }
 }
 
 @Composable
-private fun FriendRow(friend: Friend, showInvite: Boolean) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
+private fun FriendRow(friend: FriendDto, showInvite: Boolean, onInviteFriend: (String) -> Unit) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
         AvatarBadge(
-            initial = friend.name.first(),
+            initial = friend.username.firstOrNull() ?: '?',
             size = 44,
-            showOnlineIndicator = friend.isOnline,
+            showOnlineIndicator = friend.online,
             backgroundColor = MintGreen,
             textColor = PrimaryGreen,
         )
         Spacer(modifier = Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = friend.name,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.SemiBold,
-            )
-            Text(
-                text = friend.status,
-                style = MaterialTheme.typography.bodySmall,
-                color = MutedText,
-            )
+            Text(friend.username, fontWeight = FontWeight.SemiBold)
+            Text(if (friend.online) "Online" else "Offline", color = if (friend.online) OnlineGreen else MutedText)
         }
         if (showInvite) {
-            Surface(
-                onClick = {},
-                shape = MaterialTheme.shapes.extraLarge,
-                color = PrimaryGreen,
-            ) {
-                Text(
-                    text = "Invite",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = androidx.compose.ui.graphics.Color.White,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 7.dp),
-                )
-            }
+            ActionPill("Invite") { onInviteFriend(friend.userId) }
         }
     }
 }
 
 @Composable
-private fun SuggestedFriendCard(friend: Friend, modifier: Modifier = Modifier) {
-    androidx.compose.material3.Card(
-        modifier = modifier,
-        shape = MaterialTheme.shapes.large,
-        colors = androidx.compose.material3.CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface,
-        ),
-        elevation = androidx.compose.material3.CardDefaults.cardElevation(2.dp),
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            AvatarBadge(
-                initial = friend.name.first(),
-                size = 48,
-                backgroundColor = MaterialTheme.colorScheme.primaryContainer,
-                textColor = PrimaryGreen,
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = friend.name,
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.Bold,
-            )
-            Text(
-                text = "Lv. ${friend.level}",
-                style = MaterialTheme.typography.bodySmall,
-                color = MutedText,
-            )
-            Spacer(modifier = Modifier.height(10.dp))
-            Surface(
-                onClick = {},
-                shape = MaterialTheme.shapes.extraLarge,
-                color = MaterialTheme.colorScheme.primaryContainer,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(
-                    text = "+ Add",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = PrimaryGreen,
-                    fontWeight = FontWeight.Bold,
-                    textAlign = androidx.compose.ui.text.style.TextAlign.Center,
-                    modifier = Modifier.padding(vertical = 8.dp),
-                )
-            }
+private fun SearchRow(user: SocialUserDto, onSendRequest: (String) -> Unit) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(user.username, modifier = Modifier.weight(1f), fontWeight = FontWeight.SemiBold)
+        when (user.relationshipStatus) {
+            RelationshipStatus.NONE -> ActionPill("Add") { onSendRequest(user.userId) }
+            RelationshipStatus.FRIENDS -> Text("Freund", color = MutedText)
+            RelationshipStatus.INCOMING_REQUEST -> Text("Anfrage offen", color = MutedText)
+            RelationshipStatus.OUTGOING_REQUEST -> Text("Gesendet", color = MutedText)
         }
+    }
+}
+
+@Composable
+private fun RequestRow(
+    request: FriendRequestDto,
+    onAcceptRequest: (String) -> Unit,
+    onDeclineRequest: (String) -> Unit,
+) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(request.from.username, modifier = Modifier.weight(1f), fontWeight = FontWeight.SemiBold)
+        ActionPill("Accept") { onAcceptRequest(request.requestId) }
+        Spacer(modifier = Modifier.width(8.dp))
+        ActionPill("Decline") { onDeclineRequest(request.requestId) }
+    }
+}
+
+@Composable
+private fun InviteRow(
+    invite: LobbyInviteDto,
+    onAcceptInvite: (String) -> Unit,
+    onDeclineInvite: (String) -> Unit,
+) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(invite.from.username, fontWeight = FontWeight.SemiBold)
+            Text("Code ${invite.joinCode}", color = MutedText)
+        }
+        ActionPill("Join") { onAcceptInvite(invite.inviteId) }
+        Spacer(modifier = Modifier.width(8.dp))
+        ActionPill("Decline") { onDeclineInvite(invite.inviteId) }
+    }
+}
+
+@Composable
+private fun ActionPill(text: String, onClick: () -> Unit) {
+    Surface(onClick = onClick, shape = MaterialTheme.shapes.extraLarge, color = PrimaryGreen) {
+        Text(
+            text = text,
+            color = androidx.compose.ui.graphics.Color.White,
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+        )
     }
 }
 

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/friends/FriendsScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/friends/FriendsScreen.kt
@@ -75,14 +75,14 @@ fun FriendsScreen(
             OutlinedTextField(
                 value = query,
                 onValueChange = onQueryChange,
-                placeholder = { Text("User suchen") },
+                placeholder = { Text("Search users") },
                 leadingIcon = { Icon(Icons.Default.Search, contentDescription = "Search") },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )
 
             if (searchResults.isNotEmpty()) {
-                SectionCard(title = "Suche") {
+                SectionCard(title = "Search") {
                     searchResults.forEach { user ->
                         SearchRow(user = user, onSendRequest = onSendRequest)
                     }
@@ -90,7 +90,7 @@ fun FriendsScreen(
             }
 
             if (incomingRequests.isNotEmpty()) {
-                SectionCard(title = "Anfragen") {
+                SectionCard(title = "Requests") {
                     incomingRequests.forEach { request ->
                         RequestRow(request, onAcceptRequest, onDeclineRequest)
                     }
@@ -98,16 +98,16 @@ fun FriendsScreen(
             }
 
             if (lobbyInvites.isNotEmpty()) {
-                SectionCard(title = "Lobby Einladungen") {
+                SectionCard(title = "Lobby Invites") {
                     lobbyInvites.forEach { invite ->
                         InviteRow(invite, onAcceptInvite, onDeclineInvite)
                     }
                 }
             }
 
-            SectionCard(title = "Freunde") {
+            SectionCard(title = "Your Friends") {
                 if (friends.isEmpty()) {
-                    Text("Noch keine Freunde", color = MutedText)
+                    Text("No friends yet", color = MutedText)
                 } else {
                     friends.forEach { friend ->
                         FriendRow(friend, showInvite = activeLobbyId != null, onInviteFriend = onInviteFriend)
@@ -154,9 +154,9 @@ private fun SearchRow(user: SocialUserDto, onSendRequest: (String) -> Unit) {
         Text(user.username, modifier = Modifier.weight(1f), fontWeight = FontWeight.SemiBold)
         when (user.relationshipStatus) {
             RelationshipStatus.NONE -> ActionPill("Add") { onSendRequest(user.userId) }
-            RelationshipStatus.FRIENDS -> Text("Freund", color = MutedText)
-            RelationshipStatus.INCOMING_REQUEST -> Text("Anfrage offen", color = MutedText)
-            RelationshipStatus.OUTGOING_REQUEST -> Text("Gesendet", color = MutedText)
+            RelationshipStatus.FRIENDS -> Text("Friend", color = MutedText)
+            RelationshipStatus.INCOMING_REQUEST -> Text("Request pending", color = MutedText)
+            RelationshipStatus.OUTGOING_REQUEST -> Text("Sent", color = MutedText)
         }
     }
 }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/leaderboard/LeaderboardScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/leaderboard/LeaderboardScreen.kt
@@ -45,7 +45,7 @@ fun LeaderboardScreen(
             Text("Leaderboard", style = MaterialTheme.typography.headlineLarge, fontWeight = FontWeight.Bold)
             if (entries.isEmpty()) {
                 SkyjoCard {
-                    Text("Noch keine Spiele im Leaderboard", color = MutedText)
+                    Text("No games on the leaderboard yet", color = MutedText)
                 }
             } else {
                 entries.forEach { entry ->
@@ -53,7 +53,7 @@ fun LeaderboardScreen(
                         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
                             Column {
                                 Text("#${entry.rank} ${entry.username}", fontWeight = FontWeight.Bold)
-                                Text("${entry.gamesPlayed} Spiele - ${entry.wins} Wins", color = MutedText)
+                                Text("${entry.gamesPlayed} Games - ${entry.wins} Wins", color = MutedText)
                             }
                             Text("%.1f".format(entry.averageScore), color = PrimaryGreen, fontWeight = FontWeight.Bold)
                         }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/leaderboard/LeaderboardScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/leaderboard/LeaderboardScreen.kt
@@ -1,0 +1,73 @@
+package at.aau.se2.skyjo.ui.screens.leaderboard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import at.aau.se2.skyjo.model.stats.LeaderboardEntryDto
+import at.aau.se2.skyjo.ui.components.SkyjoCard
+import at.aau.se2.skyjo.ui.components.SkyjoDrawerScaffold
+import at.aau.se2.skyjo.ui.navigation.AppDestination
+import at.aau.se2.skyjo.ui.theme.MutedText
+import at.aau.se2.skyjo.ui.theme.PrimaryGreen
+import at.aau.se2.skyjo.ui.theme.SkyjoTheme
+
+@Composable
+fun LeaderboardScreen(
+    onNavigate: (AppDestination) -> Unit,
+    modifier: Modifier = Modifier,
+    entries: List<LeaderboardEntryDto> = emptyList(),
+) {
+    SkyjoDrawerScaffold(
+        currentDestination = AppDestination.Leaderboard,
+        onNavigate = onNavigate,
+        modifier = modifier,
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp, vertical = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Text("Leaderboard", style = MaterialTheme.typography.headlineLarge, fontWeight = FontWeight.Bold)
+            if (entries.isEmpty()) {
+                SkyjoCard {
+                    Text("Noch keine Spiele im Leaderboard", color = MutedText)
+                }
+            } else {
+                entries.forEach { entry ->
+                    SkyjoCard {
+                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                            Column {
+                                Text("#${entry.rank} ${entry.username}", fontWeight = FontWeight.Bold)
+                                Text("${entry.gamesPlayed} Spiele - ${entry.wins} Wins", color = MutedText)
+                            }
+                            Text("%.1f".format(entry.averageScore), color = PrimaryGreen, fontWeight = FontWeight.Bold)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LeaderboardScreenPreview() {
+    SkyjoTheme {
+        LeaderboardScreen(onNavigate = {})
+    }
+}

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/lobby/LobbyScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/lobby/LobbyScreen.kt
@@ -54,6 +54,8 @@ fun LobbyScreen(
     players: List<LobbyPlayer> = emptyList(),
     maxPlayers: Int = 6,
     isHost: Boolean = false,
+    joinCode: String? = null,
+    errorMessage: String? = null,
     onStartGame: (maxRounds: Int) -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
@@ -113,6 +115,23 @@ fun LobbyScreen(
                     style = MaterialTheme.typography.headlineLarge,
                     color = MaterialTheme.colorScheme.onBackground,
                 )
+                joinCode?.takeIf { it.isNotBlank() }?.let { code ->
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "Join Code: $code",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = PrimaryGreen,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+                errorMessage?.takeIf { it.isNotBlank() }?.let { message ->
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = message,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
             }
 
             // ── Player count bar ─────────────────────────────────────────
@@ -256,7 +275,7 @@ private fun FilledPlayerSlot(player: LobbyPlayer) {
             Spacer(modifier = Modifier.width(14.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = if (player.isHost) "${player.nickname}  👑" else player.nickname,
+                    text = player.nickname,
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.SemiBold,
                 )

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/settings/SettingsScreen.kt
@@ -102,7 +102,7 @@ fun SettingsScreen(
                                 fontWeight = FontWeight.Bold,
                             )
                             Text(
-                                text = "Session sicher gespeichert",
+                                text = "Session securely stored",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MutedText,
                             )
@@ -171,7 +171,7 @@ fun SettingsScreen(
                             modifier = Modifier.weight(1f),
                         )
                         Text(
-                            text = "Aktiv",
+                            text = "Active",
                             style = MaterialTheme.typography.labelMedium,
                             color = PrimaryGreen,
                             fontWeight = FontWeight.SemiBold,

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/settings/SettingsScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
@@ -41,14 +40,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import at.aau.se2.skyjo.ui.components.BadgeChip
 import at.aau.se2.skyjo.ui.components.SkyjoCard
 import at.aau.se2.skyjo.ui.components.SkyjoDrawerScaffold
 import at.aau.se2.skyjo.ui.navigation.AppDestination
-import at.aau.se2.skyjo.ui.theme.BlueSurface
-import at.aau.se2.skyjo.ui.theme.DeepBlue
-import at.aau.se2.skyjo.ui.theme.GoldSurface
-import at.aau.se2.skyjo.ui.theme.GoldYellow
 import at.aau.se2.skyjo.ui.theme.MintGreen
 import at.aau.se2.skyjo.ui.theme.MutedText
 import at.aau.se2.skyjo.ui.theme.PrimaryGreen
@@ -93,7 +87,7 @@ fun SettingsScreen(
                         ) {
                             Box(contentAlignment = Alignment.Center) {
                                 Text(
-                                    text = "A",
+                                    text = "S",
                                     style = MaterialTheme.typography.titleLarge,
                                     color = PrimaryGreen,
                                     fontWeight = FontWeight.ExtraBold,
@@ -102,82 +96,18 @@ fun SettingsScreen(
                         }
                         Spacer(modifier = Modifier.width(14.dp))
                         Column(modifier = Modifier.weight(1f)) {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Text(
-                                    text = "AcePlayer",
-                                    style = MaterialTheme.typography.titleMedium,
-                                    fontWeight = FontWeight.Bold,
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                BadgeChip(text = "Pro Tier")
-                            }
                             Text(
-                                text = "Level 42",
+                                text = "Skyjo Account",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                            )
+                            Text(
+                                text = "Session sicher gespeichert",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MutedText,
                             )
                         }
                     }
-                    Spacer(modifier = Modifier.height(14.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                    ) {
-                        Text(
-                            text = "Progress to Level 43",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MutedText,
-                        )
-                        Text(
-                            text = "68%",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = PrimaryGreen,
-                            fontWeight = FontWeight.Bold,
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(6.dp))
-                    LinearProgressIndicator(
-                        progress = { 0.68f },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(8.dp)
-                            .clip(MaterialTheme.shapes.extraLarge),
-                        color = PrimaryGreen,
-                        trackColor = MaterialTheme.colorScheme.primaryContainer,
-                    )
-                }
-            }
-
-            // ── Rank Card ────────────────────────────────────────────────
-            Surface(
-                shape = MaterialTheme.shapes.large,
-                color = BlueSurface,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Row(
-                    modifier = Modifier.padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(text = "🏆", style = MaterialTheme.typography.titleLarge)
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = "Global Rank",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = DeepBlue.copy(alpha = 0.7f),
-                        )
-                        Text(
-                            text = "#1,247",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = DeepBlue,
-                            fontWeight = FontWeight.ExtraBold,
-                        )
-                    }
-                    BadgeChip(
-                        text = "Top 5%",
-                        containerColor = GoldSurface,
-                        contentColor = GoldYellow,
-                    )
                 }
             }
 
@@ -236,12 +166,12 @@ fun SettingsScreen(
                         )
                         Spacer(modifier = Modifier.width(12.dp))
                         Text(
-                            text = "Link Account",
+                            text = "Session",
                             style = MaterialTheme.typography.bodyLarge,
                             modifier = Modifier.weight(1f),
                         )
                         Text(
-                            text = "Connect →",
+                            text = "Aktiv",
                             style = MaterialTheme.typography.labelMedium,
                             color = PrimaryGreen,
                             fontWeight = FontWeight.SemiBold,
@@ -258,7 +188,7 @@ fun SettingsScreen(
                     color = MutedText,
                 )
                 Text(
-                    text = "Privacy Policy · Terms of Service",
+                    text = "Privacy Policy - Terms of Service",
                     style = MaterialTheme.typography.bodySmall,
                     color = MutedText,
                 )

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/start/StartScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/start/StartScreen.kt
@@ -91,7 +91,7 @@ fun StartScreen(
                             fontWeight = FontWeight.Bold,
                         )
                         Text(
-                            text = "Bereit fuer die naechste Lobby",
+                            text = "Ready for the next lobby",
                             style = MaterialTheme.typography.bodySmall,
                             color = MutedText,
                         )
@@ -122,7 +122,7 @@ fun StartScreen(
                 )
                 Spacer(modifier = Modifier.height(12.dp))
                 PrimaryButton(
-                    text = "LOBBY ERSTELLEN",
+                    text = "CREATE LOBBY",
                     onClick = onCreateLobby,
                 )
                 Spacer(modifier = Modifier.height(12.dp))
@@ -135,7 +135,7 @@ fun StartScreen(
                 )
                 Spacer(modifier = Modifier.height(10.dp))
                 PrimaryButton(
-                    text = "MIT CODE BEITRETEN",
+                    text = "JOIN WITH CODE",
                     onClick = { onJoinLobby(joinCode) },
                     enabled = joinCode.isNotBlank(),
                 )

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/start/StartScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/start/StartScreen.kt
@@ -2,7 +2,6 @@ package at.aau.se2.skyjo.ui.screens.start
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,16 +9,17 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -27,37 +27,36 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import at.aau.se2.skyjo.model.stats.PlayerStatsDto
 import at.aau.se2.skyjo.ui.components.AvatarBadge
-import at.aau.se2.skyjo.ui.components.BadgeChip
 import at.aau.se2.skyjo.ui.components.PrimaryButton
 import at.aau.se2.skyjo.ui.components.SkyjoCard
 import at.aau.se2.skyjo.ui.components.SkyjoDrawerScaffold
 import at.aau.se2.skyjo.ui.navigation.AppDestination
-import at.aau.se2.skyjo.ui.theme.GoldSurface
-import at.aau.se2.skyjo.ui.theme.GoldYellow
-import at.aau.se2.skyjo.ui.theme.GreenDark
 import at.aau.se2.skyjo.ui.theme.MintGreen
 import at.aau.se2.skyjo.ui.theme.MutedText
-import at.aau.se2.skyjo.ui.theme.OnlineGreen
 import at.aau.se2.skyjo.ui.theme.PrimaryGreen
 import at.aau.se2.skyjo.ui.theme.SkyjoTheme
-import at.aau.se2.skyjo.ui.theme.SurfaceWhite
-
-private val onlinePlayers = listOf('K', 'M', 'R', 'T')
 
 @Composable
 fun StartScreen(
     onPlayClicked: (playerName: String) -> Unit,
     onNavigate: (AppDestination) -> Unit,
     modifier: Modifier = Modifier,
+    username: String = "",
+    stats: PlayerStatsDto? = null,
+    onCreateLobby: () -> Unit = { if (username.isNotBlank()) onPlayClicked(username) },
+    onJoinLobby: (String) -> Unit = {},
+    onLogout: () -> Unit = {},
 ) {
-    var playerName by remember { mutableStateOf("") }
+    var joinCode by remember { mutableStateOf("") }
+    val displayName = username.ifBlank { "Player" }
 
     SkyjoDrawerScaffold(
         currentDestination = AppDestination.Start,
@@ -72,120 +71,13 @@ fun StartScreen(
                 .padding(horizontal = 20.dp, vertical = 24.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            // ── Hero Card ────────────────────────────────────────────────
-            SkyjoCard {
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    // Gradient header area
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(200.dp)
-                            .background(
-                                brush = Brush.verticalGradient(
-                                    colors = listOf(PrimaryGreen, GreenDark),
-                                ),
-                                shape = MaterialTheme.shapes.medium,
-                            )
-                            .padding(20.dp),
-                    ) {
-                        Column {
-                            // Eyebrow badge
-                            Surface(
-                                shape = MaterialTheme.shapes.extraLarge,
-                                color = MintGreen.copy(alpha = 0.25f),
-                            ) {
-                                Text(
-                                    text = "ACTION MODE",
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = MintGreen,
-                                    fontWeight = FontWeight.Bold,
-                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
-                                )
-                            }
-                            Spacer(modifier = Modifier.height(12.dp))
-                            Text(
-                                text = "PLAY",
-                                style = MaterialTheme.typography.displayLarge,
-                                color = SurfaceWhite,
-                                lineHeight = 52.sp,
-                            )
-                            Text(
-                                text = "Challenge your friends\nin the ultimate card game",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = SurfaceWhite.copy(alpha = 0.75f),
-                            )
-                        }
-                        // Online players row – bottom right
-                        Row(
-                            modifier = Modifier.align(Alignment.BottomEnd),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            onlinePlayers.take(3).forEachIndexed { index, initial ->
-                                AvatarBadge(
-                                    initial = initial,
-                                    size = 28,
-                                    backgroundColor = MintGreen,
-                                    textColor = PrimaryGreen,
-                                    modifier = if (index > 0) Modifier.offset(x = (-6).dp) else Modifier,
-                                )
-                            }
-                            Spacer(modifier = Modifier.width(6.dp))
-                            Text(
-                                text = "1,284 online",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MintGreen,
-                            )
-                        }
-                    }
-
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    // Player name input
-                    OutlinedTextField(
-                        value = playerName,
-                        onValueChange = { playerName = it },
-                        label = { Text("Your Name") },
-                        placeholder = { Text("Enter your name") },
-                        singleLine = true,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp),
-                    )
-
-                    Spacer(modifier = Modifier.height(12.dp))
-
-                    // CTA button
-                    PrimaryButton(
-                        text = "START NEW SESSION",
-                        onClick = { if (playerName.isNotBlank()) onPlayClicked(playerName.trim()) },
-                        enabled = playerName.isNotBlank(),
-                        modifier = Modifier.padding(horizontal = 4.dp),
-                    )
-                }
-            }
-
-            // ── Feature Cards Row ────────────────────────────────────────
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center,
-            ) {
-                FeatureCard(
-                    emoji = "👥",
-                    title = "Friends",
-                    subtitle = "3 online",
-                    onClick = { onNavigate(AppDestination.Friends) },
-                    modifier = Modifier.fillMaxWidth(0.5f),
-                )
-            }
-
-            // ── Profile / Stats Card ─────────────────────────────────────
             SkyjoCard {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     AvatarBadge(
-                        initial = if (playerName.isNotBlank()) playerName.first() else 'A',
+                        initial = displayName.first().uppercaseChar(),
                         size = 52,
                         showOnlineIndicator = true,
                         backgroundColor = MintGreen,
@@ -193,46 +85,87 @@ fun StartScreen(
                     )
                     Spacer(modifier = Modifier.width(14.dp))
                     Column(modifier = Modifier.weight(1f)) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text(
-                                text = if (playerName.isNotBlank()) playerName else "AcePlayer",
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            BadgeChip(text = "Pro Tier")
-                        }
                         Text(
-                            text = "Level 42",
+                            text = displayName,
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        Text(
+                            text = "Bereit fuer die naechste Lobby",
                             style = MaterialTheme.typography.bodySmall,
                             color = MutedText,
                         )
                     }
+                    TextButton(onClick = onLogout) {
+                        Text("Logout")
+                    }
                 }
-                Spacer(modifier = Modifier.height(16.dp))
+
+                Spacer(modifier = Modifier.height(18.dp))
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceAround,
                 ) {
-                    StatItem(value = "127", label = "Total Wins")
+                    StatItem(value = (stats?.wins ?: 0).toString(), label = "Wins")
                     VerticalDivider()
-                    StatItem(value = "18", label = "Avg Score")
+                    StatItem(value = (stats?.gamesPlayed ?: 0).toString(), label = "Games")
                     VerticalDivider()
-                    StatItem(value = "57%", label = "Win Rate")
+                    StatItem(value = "%.1f".format(stats?.averageScore ?: 0.0), label = "Avg Score")
                 }
             }
 
-            // Bottom spacing for floating nav
-            Spacer(modifier = Modifier.height(8.dp))
+            SkyjoCard {
+                Text(
+                    text = "Lobby",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                PrimaryButton(
+                    text = "LOBBY ERSTELLEN",
+                    onClick = onCreateLobby,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = joinCode,
+                    onValueChange = { joinCode = it.uppercase().take(6) },
+                    label = { Text("Join Code") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(10.dp))
+                PrimaryButton(
+                    text = "MIT CODE BEITRETEN",
+                    onClick = { onJoinLobby(joinCode) },
+                    enabled = joinCode.isNotBlank(),
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                HomeActionCard(
+                    icon = Icons.Default.Group,
+                    title = "Friends",
+                    onClick = { onNavigate(AppDestination.Friends) },
+                    modifier = Modifier.weight(1f),
+                )
+                HomeActionCard(
+                    icon = Icons.Default.EmojiEvents,
+                    title = "Leaderboard",
+                    onClick = { onNavigate(AppDestination.Leaderboard) },
+                    modifier = Modifier.weight(1f),
+                )
+            }
         }
     }
 }
 
 @Composable
-private fun FeatureCard(
-    emoji: String,
+private fun HomeActionCard(
+    icon: ImageVector,
     title: String,
-    subtitle: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -240,27 +173,14 @@ private fun FeatureCard(
         onClick = onClick,
         modifier = modifier,
         shape = MaterialTheme.shapes.large,
-        colors = androidx.compose.material3.CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface,
-        ),
-        elevation = androidx.compose.material3.CardDefaults.cardElevation(2.dp),
     ) {
         Column(
             modifier = Modifier.padding(16.dp),
             horizontalAlignment = Alignment.Start,
         ) {
-            Text(text = emoji, style = MaterialTheme.typography.headlineMedium)
+            Icon(icon, contentDescription = title, tint = PrimaryGreen)
             Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-            )
-            Text(
-                text = subtitle,
-                style = MaterialTheme.typography.bodySmall,
-                color = MutedText,
-            )
+            Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
         }
     }
 }
@@ -285,11 +205,12 @@ private fun StatItem(value: String, label: String) {
 
 @Composable
 private fun VerticalDivider() {
-    Box(
+    androidx.compose.foundation.layout.Box(
         modifier = Modifier
             .width(1.dp)
             .height(36.dp)
-            .background(MaterialTheme.colorScheme.outline),
+            .background(Color(0xFFE5E7EB))
+            .padding(horizontal = 0.dp),
     )
 }
 
@@ -297,6 +218,11 @@ private fun VerticalDivider() {
 @Composable
 private fun StartScreenPreview() {
     SkyjoTheme {
-        StartScreen(onPlayClicked = {}, onNavigate = {})
+        StartScreen(
+            onPlayClicked = {},
+            onNavigate = {},
+            username = "Alice",
+            stats = PlayerStatsDto("user-a", "Alice", 0, 0, 0, null, 0.0),
+        )
     }
 }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/AuthViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/AuthViewModel.kt
@@ -1,0 +1,152 @@
+package at.aau.se2.skyjo.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.network.ApiException
+import at.aau.se2.skyjo.network.SkyjoApi
+import at.aau.se2.skyjo.network.SkyjoApiClient
+import at.aau.se2.skyjo.session.EncryptedSessionStore
+import at.aau.se2.skyjo.session.SessionStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class AuthUiState(
+    val isCheckingSession: Boolean = true,
+    val isAuthenticated: Boolean = false,
+    val isRegisterMode: Boolean = false,
+    val username: String = "",
+    val password: String = "",
+    val user: AuthUserDto? = null,
+    val isSubmitting: Boolean = false,
+    val errorMessage: String? = null,
+)
+
+class AuthViewModel(
+    application: Application,
+    private val sessionStore: SessionStore,
+    private val apiClient: SkyjoApi,
+) : AndroidViewModel(application) {
+
+    constructor(application: Application) : this(application, EncryptedSessionStore(application))
+
+    private constructor(
+        application: Application,
+        sessionStore: SessionStore,
+    ) : this(application, sessionStore, SkyjoApiClient(sessionStore))
+
+    private val _state = MutableStateFlow(AuthUiState())
+    val state: StateFlow<AuthUiState> = _state.asStateFlow()
+
+    init {
+        checkExistingSession()
+    }
+
+    fun updateUsername(value: String) {
+        _state.update { it.copy(username = value, errorMessage = null) }
+    }
+
+    fun updatePassword(value: String) {
+        _state.update { it.copy(password = value, errorMessage = null) }
+    }
+
+    fun toggleMode() {
+        _state.update {
+            it.copy(
+                isRegisterMode = !it.isRegisterMode,
+                password = "",
+                errorMessage = null,
+            )
+        }
+    }
+
+    fun submit() {
+        val snapshot = _state.value
+        val username = snapshot.username.trim()
+        val password = snapshot.password
+        if (!USERNAME_PATTERN.matches(username)) {
+            _state.update { it.copy(errorMessage = "Username: 3-20 Zeichen, nur Buchstaben, Zahlen und _") }
+            return
+        }
+        if (password.length < 8) {
+            _state.update { it.copy(errorMessage = "Passwort muss mindestens 8 Zeichen haben") }
+            return
+        }
+
+        viewModelScope.launch {
+            _state.update { it.copy(isSubmitting = true, errorMessage = null) }
+            runCatching {
+                if (snapshot.isRegisterMode) {
+                    apiClient.register(username, password)
+                } else {
+                    apiClient.login(username, password)
+                }
+            }.onSuccess { response ->
+                sessionStore.saveToken(response.token)
+                _state.update {
+                    it.copy(
+                        isAuthenticated = true,
+                        user = response.user,
+                        password = "",
+                        isSubmitting = false,
+                    )
+                }
+            }.onFailure { error ->
+                _state.update {
+                    it.copy(
+                        isSubmitting = false,
+                        errorMessage = error.readableMessage("Login fehlgeschlagen"),
+                    )
+                }
+            }
+        }
+    }
+
+    fun logout() {
+        viewModelScope.launch {
+            runCatching { apiClient.logout() }
+            sessionStore.clearToken()
+            _state.value = AuthUiState(isCheckingSession = false)
+        }
+    }
+
+    private fun checkExistingSession() {
+        viewModelScope.launch {
+            val token = sessionStore.getToken()
+            if (token.isNullOrBlank()) {
+                _state.update { it.copy(isCheckingSession = false) }
+                return@launch
+            }
+
+            runCatching { apiClient.me() }
+                .onSuccess { user ->
+                    _state.update {
+                        it.copy(
+                            isCheckingSession = false,
+                            isAuthenticated = true,
+                            user = user,
+                            username = user.username,
+                        )
+                    }
+                }
+                .onFailure {
+                    sessionStore.clearToken()
+                    _state.update { state -> state.copy(isCheckingSession = false, isAuthenticated = false) }
+                }
+        }
+    }
+
+    private fun Throwable.readableMessage(fallback: String): String =
+        when (this) {
+            is ApiException -> message ?: fallback
+            else -> message ?: fallback
+        }
+
+    private companion object {
+        val USERNAME_PATTERN = Regex("^[A-Za-z0-9_]{3,20}$")
+    }
+}

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/AuthViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/AuthViewModel.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import at.aau.se2.skyjo.model.auth.AuthUserDto
-import at.aau.se2.skyjo.network.ApiException
 import at.aau.se2.skyjo.network.SkyjoApi
 import at.aau.se2.skyjo.network.SkyjoApiClient
 import at.aau.se2.skyjo.session.EncryptedSessionStore
@@ -140,11 +139,7 @@ class AuthViewModel(
         }
     }
 
-    private fun Throwable.readableMessage(fallback: String): String =
-        when (this) {
-            is ApiException -> message ?: fallback
-            else -> message ?: fallback
-        }
+    private fun Throwable.readableMessage(fallback: String): String = message ?: fallback
 
     private companion object {
         val USERNAME_PATTERN = Regex("^[A-Za-z0-9_]{3,20}$")

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/AuthViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/AuthViewModel.kt
@@ -68,11 +68,11 @@ class AuthViewModel(
         val username = snapshot.username.trim()
         val password = snapshot.password
         if (!USERNAME_PATTERN.matches(username)) {
-            _state.update { it.copy(errorMessage = "Username: 3-20 Zeichen, nur Buchstaben, Zahlen und _") }
+            _state.update { it.copy(errorMessage = "Username: 3-20 characters, letters, numbers, and _ only") }
             return
         }
         if (password.length < 8) {
-            _state.update { it.copy(errorMessage = "Passwort muss mindestens 8 Zeichen haben") }
+            _state.update { it.copy(errorMessage = "Password must be at least 8 characters long") }
             return
         }
 
@@ -98,7 +98,7 @@ class AuthViewModel(
                 _state.update {
                     it.copy(
                         isSubmitting = false,
-                        errorMessage = error.readableMessage("Login fehlgeschlagen"),
+                        errorMessage = error.readableMessage("Login failed"),
                     )
                 }
             }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/FriendsViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/FriendsViewModel.kt
@@ -1,0 +1,131 @@
+package at.aau.se2.skyjo.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import at.aau.se2.skyjo.model.social.FriendDto
+import at.aau.se2.skyjo.model.social.FriendRequestDto
+import at.aau.se2.skyjo.model.social.LobbyInviteDto
+import at.aau.se2.skyjo.model.social.SocialUserDto
+import at.aau.se2.skyjo.network.SkyjoApi
+import at.aau.se2.skyjo.network.SkyjoApiClient
+import at.aau.se2.skyjo.session.EncryptedSessionStore
+import at.aau.se2.skyjo.session.SessionStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class FriendsUiState(
+    val friends: List<FriendDto> = emptyList(),
+    val incomingRequests: List<FriendRequestDto> = emptyList(),
+    val outgoingRequests: List<FriendRequestDto> = emptyList(),
+    val lobbyInvites: List<LobbyInviteDto> = emptyList(),
+    val searchResults: List<SocialUserDto> = emptyList(),
+    val query: String = "",
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+)
+
+class FriendsViewModel(
+    application: Application,
+    private val apiClient: SkyjoApi,
+) : AndroidViewModel(application) {
+
+    constructor(application: Application) : this(application, EncryptedSessionStore(application))
+
+    private constructor(
+        application: Application,
+        sessionStore: SessionStore,
+    ) : this(application, SkyjoApiClient(sessionStore))
+
+    private val _state = MutableStateFlow(FriendsUiState())
+    val state: StateFlow<FriendsUiState> = _state.asStateFlow()
+
+    fun refresh() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true, errorMessage = null) }
+            runCatching {
+                val friends = apiClient.friends()
+                val requests = apiClient.friendRequests()
+                val invites = apiClient.lobbyInvites()
+                _state.update {
+                    it.copy(
+                        friends = friends,
+                        incomingRequests = requests.incoming,
+                        outgoingRequests = requests.outgoing,
+                        lobbyInvites = invites,
+                        isLoading = false,
+                    )
+                }
+            }.onFailure { error ->
+                _state.update { it.copy(isLoading = false, errorMessage = error.message) }
+            }
+        }
+    }
+
+    fun updateSearch(query: String) {
+        _state.update { it.copy(query = query) }
+        viewModelScope.launch {
+            if (query.trim().length < 2) {
+                _state.update { it.copy(searchResults = emptyList()) }
+                return@launch
+            }
+            runCatching { apiClient.searchUsers(query) }
+                .onSuccess { results -> _state.update { it.copy(searchResults = results) } }
+        }
+    }
+
+    fun sendFriendRequest(userId: String) {
+        viewModelScope.launch {
+            runCatching { apiClient.sendFriendRequest(userId) }
+                .onSuccess { refresh() }
+                .onFailure { error -> _state.update { it.copy(errorMessage = error.message) } }
+        }
+    }
+
+    fun acceptRequest(requestId: String) {
+        viewModelScope.launch {
+            runCatching { apiClient.acceptFriendRequest(requestId) }
+                .onSuccess { refresh() }
+                .onFailure { error -> _state.update { it.copy(errorMessage = error.message) } }
+        }
+    }
+
+    fun declineRequest(requestId: String) {
+        viewModelScope.launch {
+            runCatching { apiClient.declineFriendRequest(requestId) }
+                .onSuccess { refresh() }
+                .onFailure { error -> _state.update { it.copy(errorMessage = error.message) } }
+        }
+    }
+
+    fun inviteFriend(lobbyId: String?, friendUserId: String) {
+        val activeLobbyId = lobbyId ?: return
+        viewModelScope.launch {
+            runCatching { apiClient.sendLobbyInvite(activeLobbyId, friendUserId) }
+                .onFailure { error -> _state.update { it.copy(errorMessage = error.message) } }
+        }
+    }
+
+    fun addLobbyInvite(invite: LobbyInviteDto) {
+        _state.update { state ->
+            state.copy(lobbyInvites = (state.lobbyInvites.filterNot { it.inviteId == invite.inviteId } + invite))
+        }
+    }
+
+    fun removeLobbyInvite(inviteId: String) {
+        _state.update { state ->
+            state.copy(lobbyInvites = state.lobbyInvites.filterNot { it.inviteId == inviteId })
+        }
+    }
+
+    fun declineLobbyInvite(inviteId: String) {
+        viewModelScope.launch {
+            runCatching { apiClient.declineLobbyInvite(inviteId) }
+                .onSuccess { removeLobbyInvite(inviteId) }
+                .onFailure { error -> _state.update { it.copy(errorMessage = error.message) } }
+        }
+    }
+}

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
@@ -50,7 +50,7 @@ class GameViewModel(
     val lobbyError: StateFlow<String?> = _lobbyError.asStateFlow()
 
     val isHost: StateFlow<Boolean> = combine(lobbyState, myPlayerName) { lobby, name ->
-        name.isNotEmpty() && lobby?.players?.firstOrNull()?.nickname == name
+        name.isNotEmpty() && lobby?.players?.find { it.nickname == name }?.isHost == true
     }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     val myPlayerId: StateFlow<String?> = combine(gameState, myPlayerName) { game, name ->
@@ -73,6 +73,17 @@ class GameViewModel(
                         runCatching {
                             val ticket = apiClient.createWebSocketTicket().ticket
                             gameClient.connect(ticket = ticket, lobbyJoinCode = lobbyState.value?.joinCode)
+                            apiClient.currentLobby()?.let { lobby ->
+                                gameClient.applyLobbyState(
+                                    LobbyUpdateMessage(
+                                        lobbyId = lobby.lobbyId,
+                                        joinCode = lobby.joinCode,
+                                        players = lobby.players,
+                                        status = lobby.status,
+                                        maxPlayers = lobby.maxPlayers,
+                                    ),
+                                )
+                            }
                         }
                     }
                 }
@@ -167,12 +178,14 @@ class GameViewModel(
     }
 
     fun leaveLobby() {
-        lobbyState.value?.lobbyId?.let { lobbyId ->
-            viewModelScope.launch { runCatching { apiClient.leaveLobby(lobbyId) } }
-        } ?: gameClient.leaveLobby()
-        gameClient.clearStoredGame()
-        gameClient.disconnect()
-        _myPlayerName.value = ""
+        viewModelScope.launch {
+            lobbyState.value?.lobbyId?.let { lobbyId ->
+                runCatching { apiClient.leaveLobby(lobbyId) }
+            } ?: run { gameClient.leaveLobby() }
+            gameClient.clearStoredGame()
+            gameClient.disconnect()
+            _myPlayerName.value = ""
+        }
     }
 
     fun startGame(maxRounds: Int = 3, targetScore: Int = 100) =

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
@@ -126,7 +126,7 @@ class GameViewModel(
                     ),
                 )
             }.onFailure { error ->
-                _lobbyError.value = error.message ?: "Lobby konnte nicht erstellt werden"
+                _lobbyError.value = error.message ?: "Could not create lobby"
             }
         }
     }
@@ -148,7 +148,7 @@ class GameViewModel(
                     ),
                 )
             }.onFailure { error ->
-                _lobbyError.value = error.message ?: "Lobby konnte nicht betreten werden"
+                _lobbyError.value = error.message ?: "Could not join lobby"
             }
         }
     }
@@ -172,7 +172,7 @@ class GameViewModel(
                     )
                 }
             }.onFailure { error ->
-                _lobbyError.value = error.message ?: "Einladung konnte nicht angenommen werden"
+                _lobbyError.value = error.message ?: "Could not accept invite"
             }
         }
     }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
@@ -6,18 +6,35 @@ import androidx.lifecycle.viewModelScope
 import at.aau.se2.skyjo.model.ActionCardParameters
 import at.aau.se2.skyjo.model.BoardLineTargetType
 import at.aau.se2.skyjo.model.GameAction
+import at.aau.se2.skyjo.model.LobbyUpdateMessage
 import at.aau.se2.skyjo.model.PlayActionCardCommand
+import at.aau.se2.skyjo.model.stats.PlayerStatsDto
+import at.aau.se2.skyjo.network.GameRealtimeClient
 import at.aau.se2.skyjo.network.GameStompClient
+import at.aau.se2.skyjo.network.SkyjoApi
+import at.aau.se2.skyjo.network.SkyjoApiClient
+import at.aau.se2.skyjo.session.EncryptedSessionStore
+import at.aau.se2.skyjo.session.SessionStore
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
-class GameViewModel(application: Application) : AndroidViewModel(application) {
+class GameViewModel(
+    application: Application,
+    private val apiClient: SkyjoApi,
+    private val gameClient: GameRealtimeClient,
+) : AndroidViewModel(application) {
 
-    private val gameClient = GameStompClient(application)
+    constructor(application: Application) : this(application, EncryptedSessionStore(application))
+
+    private constructor(
+        application: Application,
+        sessionStore: SessionStore,
+    ) : this(application, SkyjoApiClient(sessionStore), GameStompClient(application))
 
     val lobbyState = gameClient.lobbyState
     val gameState = gameClient.gameState
     val actionCardResults = gameClient.actionCardResults
+    val incomingInvites = gameClient.incomingInvites
     val hasRejoinedGame = gameClient.hasRejoinedGame
     val errorMessage = gameClient.errorMessage
     val connectionError = gameClient.connectionError
@@ -25,6 +42,12 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
 
     private val _myPlayerName = MutableStateFlow("")
     val myPlayerName: StateFlow<String> = _myPlayerName.asStateFlow()
+
+    private val _homeStats = MutableStateFlow<PlayerStatsDto?>(null)
+    val homeStats: StateFlow<PlayerStatsDto?> = _homeStats.asStateFlow()
+
+    private val _lobbyError = MutableStateFlow<String?>(null)
+    val lobbyError: StateFlow<String?> = _lobbyError.asStateFlow()
 
     val isHost: StateFlow<Boolean> = combine(lobbyState, myPlayerName) { lobby, name ->
         name.isNotEmpty() && lobby?.players?.firstOrNull()?.nickname == name
@@ -47,7 +70,10 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                 .collect {
                     val name = _myPlayerName.value
                     if (name.isNotEmpty()) {
-                        gameClient.reconnect(name)
+                        runCatching {
+                            val ticket = apiClient.createWebSocketTicket().ticket
+                            gameClient.connect(ticket = ticket, lobbyJoinCode = lobbyState.value?.joinCode)
+                        }
                     }
                 }
         }
@@ -61,8 +87,89 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    fun setAuthenticatedUsername(username: String) {
+        _myPlayerName.value = username
+    }
+
+    fun refreshHomeStats() {
+        viewModelScope.launch {
+            runCatching { apiClient.myStats() }
+                .onSuccess { _homeStats.value = it }
+        }
+    }
+
+    fun createLobby(username: String) {
+        _myPlayerName.value = username
+        viewModelScope.launch {
+            _lobbyError.value = null
+            runCatching {
+                val lobby = apiClient.createLobby()
+                connectToLobby(lobby.joinCode)
+                gameClient.applyLobbyState(
+                    LobbyUpdateMessage(
+                        lobbyId = lobby.lobbyId,
+                        joinCode = lobby.joinCode,
+                        players = lobby.players,
+                        status = lobby.status,
+                        maxPlayers = lobby.maxPlayers,
+                    ),
+                )
+            }.onFailure { error ->
+                _lobbyError.value = error.message ?: "Lobby konnte nicht erstellt werden"
+            }
+        }
+    }
+
+    fun joinLobbyByCode(username: String, joinCode: String) {
+        _myPlayerName.value = username
+        viewModelScope.launch {
+            _lobbyError.value = null
+            runCatching {
+                val lobby = apiClient.joinLobby(joinCode)
+                connectToLobby(lobby.joinCode)
+                gameClient.applyLobbyState(
+                    LobbyUpdateMessage(
+                        lobbyId = lobby.lobbyId,
+                        joinCode = lobby.joinCode,
+                        players = lobby.players,
+                        status = lobby.status,
+                        maxPlayers = lobby.maxPlayers,
+                    ),
+                )
+            }.onFailure { error ->
+                _lobbyError.value = error.message ?: "Lobby konnte nicht betreten werden"
+            }
+        }
+    }
+
+    fun acceptLobbyInvite(username: String, inviteId: String) {
+        _myPlayerName.value = username
+        viewModelScope.launch {
+            runCatching {
+                val invite = apiClient.acceptLobbyInvite(inviteId)
+                val lobby = apiClient.currentLobby()
+                connectToLobby(invite.joinCode)
+                lobby?.let {
+                    gameClient.applyLobbyState(
+                        LobbyUpdateMessage(
+                            lobbyId = it.lobbyId,
+                            joinCode = it.joinCode,
+                            players = it.players,
+                            status = it.status,
+                            maxPlayers = it.maxPlayers,
+                        ),
+                    )
+                }
+            }.onFailure { error ->
+                _lobbyError.value = error.message ?: "Einladung konnte nicht angenommen werden"
+            }
+        }
+    }
+
     fun leaveLobby() {
-        gameClient.leaveLobby()
+        lobbyState.value?.lobbyId?.let { lobbyId ->
+            viewModelScope.launch { runCatching { apiClient.leaveLobby(lobbyId) } }
+        } ?: gameClient.leaveLobby()
         gameClient.clearStoredGame()
         gameClient.disconnect()
         _myPlayerName.value = ""
@@ -152,5 +259,10 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     override fun onCleared() {
         super.onCleared()
         gameClient.close()
+    }
+
+    private suspend fun connectToLobby(joinCode: String) {
+        val ticket = apiClient.createWebSocketTicket().ticket
+        gameClient.connect(ticket = ticket, lobbyJoinCode = joinCode)
     }
 }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/LeaderboardViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/LeaderboardViewModel.kt
@@ -1,0 +1,46 @@
+package at.aau.se2.skyjo.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import at.aau.se2.skyjo.model.stats.LeaderboardEntryDto
+import at.aau.se2.skyjo.network.SkyjoApi
+import at.aau.se2.skyjo.network.SkyjoApiClient
+import at.aau.se2.skyjo.session.EncryptedSessionStore
+import at.aau.se2.skyjo.session.SessionStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class LeaderboardUiState(
+    val entries: List<LeaderboardEntryDto> = emptyList(),
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+)
+
+class LeaderboardViewModel(
+    application: Application,
+    private val apiClient: SkyjoApi,
+) : AndroidViewModel(application) {
+
+    constructor(application: Application) : this(application, EncryptedSessionStore(application))
+
+    private constructor(
+        application: Application,
+        sessionStore: SessionStore,
+    ) : this(application, SkyjoApiClient(sessionStore))
+
+    private val _state = MutableStateFlow(LeaderboardUiState())
+    val state: StateFlow<LeaderboardUiState> = _state.asStateFlow()
+
+    fun refresh() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true, errorMessage = null) }
+            runCatching { apiClient.leaderboard() }
+                .onSuccess { entries -> _state.update { it.copy(entries = entries, isLoading = false) } }
+                .onFailure { error -> _state.update { it.copy(isLoading = false, errorMessage = error.message) } }
+        }
+    }
+}

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ModelDtoCoverageTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ModelDtoCoverageTest.kt
@@ -1,0 +1,76 @@
+package at.aau.se2.skyjo
+
+import at.aau.se2.skyjo.model.LobbyPlayer
+import at.aau.se2.skyjo.model.auth.AuthResponse
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.auth.ErrorResponse
+import at.aau.se2.skyjo.model.auth.LoginRequest
+import at.aau.se2.skyjo.model.auth.RegisterRequest
+import at.aau.se2.skyjo.model.auth.WsTicketResponse
+import at.aau.se2.skyjo.model.lobby.LobbySummaryResponse
+import at.aau.se2.skyjo.model.social.FriendDto
+import at.aau.se2.skyjo.model.social.FriendRequestDto
+import at.aau.se2.skyjo.model.social.FriendRequestStatus
+import at.aau.se2.skyjo.model.social.FriendRequestsResponse
+import at.aau.se2.skyjo.model.social.LobbyInviteDto
+import at.aau.se2.skyjo.model.social.LobbyInviteRequest
+import at.aau.se2.skyjo.model.social.LobbyInviteStatus
+import at.aau.se2.skyjo.model.social.RelationshipStatus
+import at.aau.se2.skyjo.model.social.SendFriendRequestRequest
+import at.aau.se2.skyjo.model.social.SocialUserDto
+import at.aau.se2.skyjo.model.stats.LeaderboardEntryDto
+import at.aau.se2.skyjo.model.stats.PlayerStatsDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ModelDtoCoverageTest {
+
+    @Test
+    fun `auth lobby stats and social DTOs expose constructor values`() {
+        val user = AuthUserDto("user-1", "Alice")
+        assertEquals("Alice", AuthResponse("token", user).user.username)
+        assertEquals("Alice", RegisterRequest("Alice", "secret").username)
+        assertEquals("secret", LoginRequest("Alice", "secret").password)
+        assertEquals("ticket", WsTicketResponse("ticket", 10L).ticket)
+        assertEquals("error", ErrorResponse("error").message)
+
+        val lobby = LobbySummaryResponse("lobby-1", "ABC123", listOf(LobbyPlayer("Alice", true)), "WAITING", 6)
+        assertEquals("ABC123", lobby.joinCode)
+        assertTrue(lobby.players.single().isHost)
+
+        val stats = PlayerStatsDto("user-1", "Alice", 2, 1, 20, 5, 10.0)
+        assertEquals(10.0, stats.averageScore, 0.0)
+        val entry = LeaderboardEntryDto(1, "user-1", "Alice", 10.0, 1, 2, 5, 20)
+        assertEquals(1, entry.rank)
+
+        val socialUser = SocialUserDto("user-2", "Bob", RelationshipStatus.FRIENDS)
+        val friend = FriendDto("user-2", "Bob", online = true, currentLobbyId = "lobby-1")
+        val friendRequest = FriendRequestDto(
+            "request-1",
+            from = socialUser,
+            to = SocialUserDto("user-1", "Alice"),
+            status = FriendRequestStatus.PENDING,
+            createdAt = 1L,
+            respondedAt = null,
+        )
+        val requests = FriendRequestsResponse(incoming = listOf(friendRequest), outgoing = emptyList())
+        val invite = LobbyInviteDto(
+            "invite-1",
+            "lobby-1",
+            "ABC123",
+            from = socialUser,
+            to = SocialUserDto("user-1", "Alice"),
+            status = LobbyInviteStatus.PENDING,
+            createdAt = 2L,
+            respondedAt = null,
+        )
+
+        assertEquals("lobby-1", friend.currentLobbyId)
+        assertEquals(friendRequest, requests.incoming.single())
+        assertEquals("user-2", SendFriendRequestRequest("user-2").toUserId)
+        assertEquals("user-2", LobbyInviteRequest("user-2").toUserId)
+        assertEquals("ABC123", invite.joinCode)
+        assertEquals(LobbyInviteStatus.ACCEPTED, invite.copy(status = LobbyInviteStatus.ACCEPTED).status)
+    }
+}

--- a/app/src/test/kotlin/at/aau/se2/skyjo/TestDoubles.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/TestDoubles.kt
@@ -1,0 +1,19 @@
+package at.aau.se2.skyjo
+
+import at.aau.se2.skyjo.session.SessionStore
+
+class InMemorySessionStore(initialToken: String? = null) : SessionStore {
+    var storedToken: String? = initialToken
+    var clearCount = 0
+
+    override fun saveToken(token: String) {
+        this.storedToken = token
+    }
+
+    override fun getToken(): String? = storedToken
+
+    override fun clearToken() {
+        storedToken = null
+        clearCount++
+    }
+}

--- a/app/src/test/kotlin/at/aau/se2/skyjo/network/GameStompClientTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/network/GameStompClientTest.kt
@@ -533,6 +533,56 @@ class GameStompClientTest {
     }
 
     @Test
+    fun `rejoin state does not set hasRejoinedGame for round finished game JSON`() = runBlocking {
+        val client = GameStompClient(mockContext)
+        client.connect()
+        delay(300)
+
+        val finishedGameJson = """
+            {
+                "phase": "ROUND_FINISHED",
+                "currentPlayerId": null,
+                "roundNumber": 2,
+                "gameOver": false,
+                "totalScores": [],
+                "players": [],
+                "disconnectedPlayers": []
+            }
+        """.trimIndent()
+
+        topicFlow.emit(finishedGameJson)
+        delay(500)
+
+        assert(!client.hasRejoinedGame.value) { "Expected finished rejoin JSON not to trigger rejoin navigation" }
+    }
+
+    @Test
+    fun `game over update clears stored game id`() = runBlocking {
+        val client = GameStompClient(mockContext)
+        client.connect()
+        delay(300)
+
+        val gameOverJson = """
+            {
+                "phase": "ROUND_FINISHED",
+                "currentPlayerId": null,
+                "roundNumber": 2,
+                "gameOver": true,
+                "gameId": "game-123",
+                "totalScores": [],
+                "players": [],
+                "disconnectedPlayers": []
+            }
+        """.trimIndent()
+
+        topicFlow.emit(gameOverJson)
+        delay(500)
+
+        verify(atLeast = 1) { mockEditor.remove("game_id") }
+        verify(atLeast = 1) { mockEditor.apply() }
+    }
+
+    @Test
     fun `game invalid JSON is handled without crash`() = runBlocking {
         val client = GameStompClient(mockContext)
         client.connect()

--- a/app/src/test/kotlin/at/aau/se2/skyjo/network/GameStompClientTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/network/GameStompClientTest.kt
@@ -78,14 +78,14 @@ class GameStompClientTest {
     }
 
     @Test
-    fun `connect uses university backend websocket url`() = runBlocking {
+    fun `connect uses configured websocket url`() = runBlocking {
         val client = GameStompClient(mockContext)
         client.connect()
         delay(300)
 
         coVerify(atLeast = 1) {
             anyConstructed<StompClient>().connect(
-                url = "ws://se2-demo.aau.at:53209/ws",
+                url = SkyjoApiClient.WS_BASE_URL,
                 any(),
                 any(),
                 any(),

--- a/app/src/test/kotlin/at/aau/se2/skyjo/network/SkyjoApiClientTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/network/SkyjoApiClientTest.kt
@@ -1,0 +1,160 @@
+package at.aau.se2.skyjo.network
+
+import at.aau.se2.skyjo.InMemorySessionStore
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SkyjoApiClientTest {
+
+    @Test
+    fun `auth methods send expected requests and decode responses`() = runBlocking {
+        val responder = QueueResponder(
+            201 to authJson("token-a", "user-a", "Alice"),
+            200 to authJson("token-b", "user-a", "Alice"),
+            200 to """{"userId":"user-a","username":"Alice"}""",
+            204 to "",
+            200 to """{"ticket":"ws-ticket","expiresAt":12345}""",
+        )
+        val api = SkyjoApiClient(InMemorySessionStore("session-token"), responder.client, "http://localhost")
+
+        assertEquals("token-a", api.register("Alice", "SecurePass123").token)
+        assertEquals("token-b", api.login("Alice", "SecurePass123").token)
+        assertEquals("Alice", api.me().username)
+        api.logout()
+        assertEquals("ws-ticket", api.createWebSocketTicket().ticket)
+
+        assertEquals(listOf("POST", "POST", "GET", "POST", "POST"), responder.records.map { it.method })
+        assertEquals(
+            listOf("/api/auth/register", "/api/auth/login", "/api/auth/me", "/api/auth/logout", "/api/auth/ws-ticket"),
+            responder.records.map { it.path },
+        )
+        assertTrue(responder.records.all { it.authorization == "Bearer session-token" })
+        assertTrue(responder.records[0].body.contains("\"username\":\"Alice\""))
+    }
+
+    @Test
+    fun `lobby stats and social methods encode paths and decode responses`() = runBlocking {
+        val lobbyJson = """{"lobbyId":"lobby/1","joinCode":"ABC123","players":[{"nickname":"Alice","isHost":true}],"status":"WAITING","maxPlayers":6}"""
+        val friendJson = """[{"userId":"friend-1","username":"Friend","online":true,"currentLobbyId":"lobby-1"}]"""
+        val requestsJson = """{"incoming":[],"outgoing":[]}"""
+        val inviteJson = """{"inviteId":"invite-1","lobbyId":"lobby-1","joinCode":"ABC123","from":{"userId":"from","username":"From"},"to":{"userId":"to","username":"To"},"status":"PENDING","createdAt":1}"""
+        val responder = QueueResponder(
+            200 to """{"userId":"user-a","username":"Alice","gamesPlayed":1,"wins":1,"totalScore":5,"bestScore":5,"averageScore":5.0}""",
+            200 to """[{"rank":1,"userId":"user-a","username":"Alice","averageScore":5.0,"wins":1,"gamesPlayed":1,"bestScore":5,"totalScore":5}]""",
+            201 to lobbyJson,
+            200 to lobbyJson,
+            204 to "",
+            200 to lobbyJson,
+            200 to """[{"userId":"user-b","username":"Bob","relationshipStatus":"NONE"}]""",
+            200 to friendJson,
+            200 to requestsJson,
+            201 to """{"requestId":"request-1","from":{"userId":"from","username":"From"},"to":{"userId":"to","username":"To"},"status":"PENDING","createdAt":1}""",
+            200 to """{"requestId":"request-1","from":{"userId":"from","username":"From"},"to":{"userId":"to","username":"To"},"status":"ACCEPTED","createdAt":1,"respondedAt":2}""",
+            200 to """{"requestId":"request-1","from":{"userId":"from","username":"From"},"to":{"userId":"to","username":"To"},"status":"DECLINED","createdAt":1,"respondedAt":2}""",
+            200 to """[$inviteJson]""",
+            201 to inviteJson,
+            200 to inviteJson.replace("\"PENDING\"", "\"ACCEPTED\""),
+            200 to inviteJson.replace("\"PENDING\"", "\"DECLINED\""),
+        )
+        val api = SkyjoApiClient(InMemorySessionStore("session-token"), responder.client, "http://localhost")
+
+        assertEquals(1, api.myStats().gamesPlayed)
+        assertEquals("Alice", api.leaderboard(limit = 3).single().username)
+        assertEquals("ABC123", api.createLobby().joinCode)
+        assertEquals("ABC123", api.joinLobby("AB C123").joinCode)
+        assertNull(api.currentLobby())
+        assertEquals("lobby/1", api.leaveLobby("lobby/1").lobbyId)
+        assertEquals("Bob", api.searchUsers("Bo B").single().username)
+        assertEquals("Friend", api.friends().single().username)
+        assertTrue(api.friendRequests().incoming.isEmpty())
+        assertEquals("request-1", api.sendFriendRequest("friend-1").requestId)
+        assertEquals("ACCEPTED", api.acceptFriendRequest("request/1").status.name)
+        assertEquals("DECLINED", api.declineFriendRequest("request/1").status.name)
+        assertEquals("invite-1", api.lobbyInvites().single().inviteId)
+        assertEquals("ABC123", api.sendLobbyInvite("lobby/1", "friend-1").joinCode)
+        assertEquals("ACCEPTED", api.acceptLobbyInvite("invite/1").status.name)
+        assertEquals("DECLINED", api.declineLobbyInvite("invite/1").status.name)
+
+        val paths = responder.records.map { it.path }
+        assertTrue(paths.contains("/api/lobbies/AB+C123/join"))
+        assertTrue(paths.contains("/api/lobbies/lobby%2F1/leave"))
+        assertTrue(paths.contains("/api/users/search?query=Bo+B"))
+        assertTrue(paths.contains("/api/friends/requests/request%2F1/accept"))
+        assertTrue(paths.contains("/api/lobbies/lobby%2F1/invites"))
+        assertTrue(paths.contains("/api/lobbies/invites/invite%2F1/decline"))
+    }
+
+    @Test
+    fun `error responses throw API exception with server message`() = runBlocking {
+        val responder = QueueResponder(400 to """{"message":"bad request"}""")
+        val api = SkyjoApiClient(InMemorySessionStore(), responder.client, "http://localhost")
+
+        val error = runCatching { api.login("Alice", "wrong") }.exceptionOrNull()
+
+        assertTrue(error is ApiException)
+        assertEquals("bad request", error?.message)
+        assertEquals(400, (error as ApiException).statusCode)
+    }
+
+    @Test
+    fun `plain error responses fall back to response message`() = runBlocking {
+        val responder = QueueResponder(500 to "not-json")
+        val api = SkyjoApiClient(InMemorySessionStore(), responder.client, "http://localhost")
+
+        val error = runCatching { api.me() }.exceptionOrNull()
+
+        assertTrue(error is ApiException)
+        assertEquals(500, (error as ApiException).statusCode)
+    }
+
+    private fun authJson(token: String, userId: String, username: String) =
+        """{"token":"$token","user":{"userId":"$userId","username":"$username"}}"""
+
+    private data class Record(
+        val method: String,
+        val path: String,
+        val authorization: String?,
+        val body: String,
+    )
+
+    private class QueueResponder(vararg responses: Pair<Int, String>) {
+        private val responses = ArrayDeque(responses.toList())
+        val records = mutableListOf<Record>()
+        val client: OkHttpClient = OkHttpClient.Builder()
+            .addInterceptor(interceptor())
+            .build()
+
+        private fun interceptor() = Interceptor { chain ->
+            val request = chain.request()
+            val body = request.body?.let {
+                val buffer = Buffer()
+                it.writeTo(buffer)
+                buffer.readUtf8()
+            }.orEmpty()
+            records += Record(
+                method = request.method,
+                path = request.url.encodedPath + request.url.encodedQuery?.let { "?$it" }.orEmpty(),
+                authorization = request.header("Authorization"),
+                body = body,
+            )
+            val (code, payload) = responses.removeFirst()
+            Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(code)
+                .message(if (code in 200..299) "OK" else "Error")
+                .body(payload.toResponseBody("application/json".toMediaType()))
+                .build()
+        }
+    }
+}

--- a/app/src/test/kotlin/at/aau/se2/skyjo/network/SkyjoApiDefaultTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/network/SkyjoApiDefaultTest.kt
@@ -1,0 +1,35 @@
+package at.aau.se2.skyjo.network
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class SkyjoApiDefaultTest {
+
+    private val api = object : SkyjoApi {}
+
+    @Test
+    fun `default interface methods fail loudly when not implemented`() {
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.register("a", "b") } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.login("a", "b") } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.me() } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.logout() } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.createWebSocketTicket() } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.myStats() } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.leaderboard() } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.createLobby() } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.joinLobby("ABC123") } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.currentLobby() } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.leaveLobby("lobby") } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.searchUsers("a") } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.friends() } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.friendRequests() } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.sendFriendRequest("user") } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.acceptFriendRequest("request") } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.declineFriendRequest("request") } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.lobbyInvites() } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.sendLobbyInvite("lobby", "user") } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.acceptLobbyInvite("invite") } }
+        assertThrows(UnsupportedOperationException::class.java) { runBlocking { api.declineLobbyInvite("invite") } }
+    }
+}

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/components/CommonComponentsTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/components/CommonComponentsTest.kt
@@ -146,10 +146,10 @@ class CommonComponentsTest {
     fun badgeChip_shows_text() {
         composeTestRule.setContent {
             SkyjoTheme {
-                BadgeChip(text = "Pro Tier")
+                BadgeChip(text = "Status")
             }
         }
-        composeTestRule.onNodeWithText("Pro Tier").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Status").assertIsDisplayed()
     }
 
     // ── AvatarBadge ───────────────────────────────────────────────────────

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/components/SkyjoScaffoldTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/components/SkyjoScaffoldTest.kt
@@ -125,7 +125,7 @@ class SkyjoScaffoldTest {
                 SkyjoDrawerContent(onNavigate = {})
             }
         }
-        composeTestRule.onNodeWithText("AcePlayer").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Skyjo").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHostTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHostTest.kt
@@ -155,7 +155,7 @@ class AppNavHostTest {
         composeTestRule.onAllNodesWithText("Friends").onLast().performClick()
         composeTestRule.waitForIdle()
 
-        composeTestRule.onNodeWithText("Noch keine Freunde").assertExists()
+        composeTestRule.onNodeWithText("No friends yet").assertExists()
     }
 
     @Test
@@ -175,7 +175,7 @@ class AppNavHostTest {
         }
         composeTestRule.waitForIdle()
 
-        composeTestRule.onNodeWithText("Noch keine Spiele im Leaderboard").assertExists()
+        composeTestRule.onNodeWithText("No games on the leaderboard yet").assertExists()
     }
 
     @Test
@@ -225,7 +225,7 @@ class AppNavHostTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Verbindung unterbrochen, versuche erneut...").assertExists()
+        composeTestRule.onNodeWithText("Connection interrupted, retrying...").assertExists()
     }
 
     @Test
@@ -324,7 +324,7 @@ class AppNavHostTest {
     fun appNavHost_game_screen_play_swap_own_cards_reaches_viewmodel() {
         val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
 
-        // WICHTIG: Überschreibe den Typ der Aktionskarte!
+        // Important: override the action card type.
         fakeGameState.value = makeGameState(actionCardKind = "SWAP_OWN_CARDS")
         viewModel.connect("Alice")
 
@@ -335,39 +335,38 @@ class AppNavHostTest {
         }
         composeTestRule.waitForIdle()
 
-        // 1. In den GameScreen navigieren
+        // 1. Navigate to the game screen
         fakeHasRejoinedGame.value = true
         composeTestRule.waitForIdle()
 
-        // 2. Aktionskarte auswählen
+        // 2. Select action card
         composeTestRule.onNodeWithTag("play_action_card_0").performScrollTo().performClick()
         composeTestRule.waitForIdle()
 
-        // 3. Erste eigene Karte auswählen
+        // 3. Select first own card
         composeTestRule.onAllNodesWithText("3").onFirst().performScrollTo().performClick()
         composeTestRule.waitForIdle()
 
-        // 4. Zweite eigene Karte auswählen
+        // 4. Select second own card
         composeTestRule.onAllNodesWithText("3").onLast().performScrollTo().performClick()
         composeTestRule.waitForIdle()
 
-        // 5. Verifizieren
+        // 5. Verify
         verify {
             mockGameClient.sendAction(
                 match { action ->
-                    // Achte darauf, dass dies exakt mit deinem GameAction-Modell übereinstimmt.
-                    // Wenn dein ViewModel für SwapOwnCards z.B. einen anderen type-String schickt,
-                    // musst du das hier anpassen.
+                    // Make sure this matches the GameAction model exactly.
+                    // Adjust this if the ViewModel sends a different type string for SwapOwnCards.
                     action.type == "PLAY_ACTION_CARD" &&
                             action.actionCardIndex == 0
                 }
             )
         }
     }
-    //hilfsfunktion
+    // Helper function
     private fun makeGameState(
         myPlayerId: String = "p1",
-        actionCardKind: String = "PLAYER_SWAP" // Standardwert für alte Tests beibehalten
+        actionCardKind: String = "PLAYER_SWAP" // Keep the default value for older tests
     ) = GameUpdateMessage(
         phase = "AWAITING_DRAW",
         currentPlayerId = myPlayerId,

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHostTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHostTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import at.aau.se2.skyjo.model.ActionCard
@@ -139,6 +140,85 @@ class AppNavHostTest {
             }
         }
         composeTestRule.onNodeWithText("SKYJO", substring = true).assertExists()
+    }
+
+    @Test
+    fun appNavHost_navigates_to_friends_from_start_screen() {
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        composeTestRule.setContent {
+            SkyjoTheme {
+                AppNavHost(navController = rememberNavController(), gameViewModel = viewModel)
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onAllNodesWithText("Friends").onLast().performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Noch keine Freunde").assertExists()
+    }
+
+    @Test
+    fun appNavHost_renders_leaderboard_route() {
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        lateinit var navController: NavHostController
+        composeTestRule.setContent {
+            SkyjoTheme {
+                navController = rememberNavController()
+                AppNavHost(navController = navController, gameViewModel = viewModel)
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            navController.navigate(AppDestination.Leaderboard.route)
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Noch keine Spiele im Leaderboard").assertExists()
+    }
+
+    @Test
+    fun appNavHost_renders_lobby_route_with_current_lobby_state() {
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        viewModel.setAuthenticatedUsername("Alice")
+        fakeLobbyState.value = LobbyUpdateMessage(
+            lobbyId = "lobby-1",
+            joinCode = "ABC123",
+            players = listOf(LobbyPlayer("Alice", isHost = true)),
+            status = "WAITING",
+            maxPlayers = 6,
+        )
+        lateinit var navController: NavHostController
+        composeTestRule.setContent {
+            SkyjoTheme {
+                navController = rememberNavController()
+                AppNavHost(navController = navController, gameViewModel = viewModel)
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            navController.navigate(AppDestination.Lobby.route)
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Join Code: ABC123").assertExists()
+        composeTestRule.onNodeWithText("1 / 6").assertExists()
+    }
+
+    @Test
+    fun appNavHost_shows_connection_banner_for_named_disconnected_player() {
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        viewModel.setAuthenticatedUsername("Alice")
+
+        composeTestRule.setContent {
+            SkyjoTheme {
+                AppNavHost(navController = rememberNavController(), gameViewModel = viewModel)
+            }
+        }
+
+        composeTestRule.onNodeWithText("Verbindung unterbrochen, versuche erneut...").assertExists()
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHostTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHostTest.kt
@@ -208,9 +208,16 @@ class AppNavHostTest {
     }
 
     @Test
-    fun appNavHost_shows_connection_banner_for_named_disconnected_player() {
+    fun appNavHost_shows_connection_banner_for_active_disconnected_session() {
         val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.setAuthenticatedUsername("Alice")
+        fakeLobbyState.value = LobbyUpdateMessage(
+            lobbyId = "lobby-1",
+            joinCode = "ABC123",
+            players = listOf(LobbyPlayer("Alice", isHost = true)),
+            status = "WAITING",
+            maxPlayers = 6,
+        )
 
         composeTestRule.setContent {
             SkyjoTheme {

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHostTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHostTest.kt
@@ -20,7 +20,10 @@ import at.aau.se2.skyjo.model.GameUpdateMessage
 import at.aau.se2.skyjo.model.LobbyPlayer
 import at.aau.se2.skyjo.model.LobbyUpdateMessage
 import at.aau.se2.skyjo.model.TotalScore
-import at.aau.se2.skyjo.network.GameStompClient
+import at.aau.se2.skyjo.model.auth.WsTicketResponse
+import at.aau.se2.skyjo.model.social.LobbyInviteDto
+import at.aau.se2.skyjo.network.GameRealtimeClient
+import at.aau.se2.skyjo.network.SkyjoApi
 import at.aau.se2.skyjo.ui.theme.SkyjoTheme
 import at.aau.se2.skyjo.viewmodel.GameViewModel
 import io.mockk.clearAllMocks
@@ -28,7 +31,6 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkConstructor
 import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
@@ -54,10 +56,13 @@ class AppNavHostTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private val mockApplication = mockk<Application>(relaxed = true)
+    private val mockApi = mockk<SkyjoApi>(relaxed = true)
+    private val mockGameClient = mockk<GameRealtimeClient>(relaxed = true)
 
     private val fakeLobbyState = MutableStateFlow<LobbyUpdateMessage?>(null)
     private val fakeGameState = MutableStateFlow<GameUpdateMessage?>(null)
     private val fakeActionCardResults = MutableSharedFlow<ActionCardResultMessage>()
+    private val fakeIncomingInvites = MutableSharedFlow<LobbyInviteDto>()
     private val fakeErrorMessage = MutableSharedFlow<String>()
     private val fakeConnectionError = MutableStateFlow<String?>(null)
     private val fakeIsConnected = MutableStateFlow(false)
@@ -66,23 +71,32 @@ class AppNavHostTest {
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        mockkConstructor(GameStompClient::class)
-        every { anyConstructed<GameStompClient>().lobbyState } returns fakeLobbyState
-        every { anyConstructed<GameStompClient>().gameState } returns fakeGameState
-        every { anyConstructed<GameStompClient>().actionCardResults } returns fakeActionCardResults
-        every { anyConstructed<GameStompClient>().errorMessage } returns fakeErrorMessage
-        every { anyConstructed<GameStompClient>().connectionError } returns fakeConnectionError
-        every { anyConstructed<GameStompClient>().isConnected } returns fakeIsConnected
-        every { anyConstructed<GameStompClient>().hasRejoinedGame } returns fakeHasRejoinedGame
-        coEvery { anyConstructed<GameStompClient>().connect() } just runs
-        coEvery { anyConstructed<GameStompClient>().reconnect(any()) } just runs
-        every { anyConstructed<GameStompClient>().joinLobby(any(), any()) } just runs
-        every { anyConstructed<GameStompClient>().leaveLobby() } just runs
-        every { anyConstructed<GameStompClient>().startGame(any(), any()) } just runs
-        every { anyConstructed<GameStompClient>().sendAction(any()) } just runs
-        every { anyConstructed<GameStompClient>().playActionCard(any()) } just runs
-        every { anyConstructed<GameStompClient>().disconnect() } just runs
-        every { anyConstructed<GameStompClient>().close() } just runs
+        fakeLobbyState.value = null
+        fakeGameState.value = null
+        fakeConnectionError.value = null
+        fakeIsConnected.value = false
+        fakeHasRejoinedGame.value = false
+
+        every { mockGameClient.lobbyState } returns fakeLobbyState
+        every { mockGameClient.gameState } returns fakeGameState
+        every { mockGameClient.actionCardResults } returns fakeActionCardResults
+        every { mockGameClient.incomingInvites } returns fakeIncomingInvites
+        every { mockGameClient.errorMessage } returns fakeErrorMessage
+        every { mockGameClient.connectionError } returns fakeConnectionError
+        every { mockGameClient.isConnected } returns fakeIsConnected
+        every { mockGameClient.hasRejoinedGame } returns fakeHasRejoinedGame
+        coEvery { mockGameClient.connect() } just runs
+        coEvery { mockGameClient.connect(any(), any()) } just runs
+        coEvery { mockGameClient.reconnect(any()) } just runs
+        coEvery { mockApi.createWebSocketTicket() } returns WsTicketResponse("ticket", Long.MAX_VALUE)
+        every { mockGameClient.joinLobby(any(), any()) } just runs
+        every { mockGameClient.leaveLobby() } just runs
+        every { mockGameClient.startGame(any(), any()) } just runs
+        every { mockGameClient.sendAction(any()) } just runs
+        every { mockGameClient.playActionCard(any()) } just runs
+        every { mockGameClient.clearStoredGame() } just runs
+        every { mockGameClient.disconnect() } just runs
+        every { mockGameClient.close() } just runs
     }
 
     @After
@@ -118,7 +132,7 @@ class AppNavHostTest {
 
     @Test
     fun appNavHost_renders_start_screen_by_default() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         composeTestRule.setContent {
             SkyjoTheme {
                 AppNavHost(navController = rememberNavController(), gameViewModel = viewModel)
@@ -129,7 +143,7 @@ class AppNavHostTest {
 
     @Test
     fun appNavHost_navigates_to_game_screen_when_lobby_status_is_in_game() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         fakeGameState.value = makeGameState()
 
         composeTestRule.setContent {
@@ -153,7 +167,7 @@ class AppNavHostTest {
 
     @Test
     fun appNavHost_game_screen_discard_action_card_reaches_viewmodel() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         fakeGameState.value = makeGameState()
         viewModel.connect("Alice")
 
@@ -173,7 +187,7 @@ class AppNavHostTest {
         composeTestRule.waitForIdle()
 
         verify {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 GameAction(type = "DISCARD_ACTION_CARD", actionCardIndex = 0)
             )
         }
@@ -181,7 +195,7 @@ class AppNavHostTest {
 
     @Test
     fun appNavHost_game_screen_play_swap_card_reaches_viewmodel() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         fakeGameState.value = makeGameState()
         viewModel.connect("Alice")
 
@@ -213,7 +227,7 @@ class AppNavHostTest {
         composeTestRule.waitForIdle()
 
         verify {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 match { it.type == "PLAY_ACTION_CARD" && it.actionCardIndex == 0 }
             )
         }
@@ -221,7 +235,7 @@ class AppNavHostTest {
 
     @Test
     fun appNavHost_game_screen_play_swap_own_cards_reaches_viewmodel() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
 
         // WICHTIG: Überschreibe den Typ der Aktionskarte!
         fakeGameState.value = makeGameState(actionCardKind = "SWAP_OWN_CARDS")
@@ -252,7 +266,7 @@ class AppNavHostTest {
 
         // 5. Verifizieren
         verify {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 match { action ->
                     // Achte darauf, dass dies exakt mit deinem GameAction-Modell übereinstimmt.
                     // Wenn dein ViewModel für SwapOwnCards z.B. einen anderen type-String schickt,

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/friends/FriendsScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/friends/FriendsScreenTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import at.aau.se2.skyjo.model.social.FriendDto
+import at.aau.se2.skyjo.model.social.SocialUserDto
 import at.aau.se2.skyjo.ui.theme.SkyjoTheme
 import org.junit.Rule
 import org.junit.Test
@@ -41,56 +43,60 @@ class FriendsScreenTest {
     }
 
     @Test
-    fun friendsScreen_shows_online_friends_section() {
+    fun friendsScreen_shows_friends_section() {
         composeTestRule.setContent {
             SkyjoTheme {
                 FriendsScreen(onNavigate = {})
             }
         }
-        composeTestRule.onNodeWithText("Online Friends (3)").assertIsDisplayed()
-    }
-
-    // "Suggested Friends" may be below the visible fold in the test viewport
-    @Test
-    fun friendsScreen_shows_suggested_friends_section() {
-        composeTestRule.setContent {
-            SkyjoTheme {
-                FriendsScreen(onNavigate = {})
-            }
-        }
-        composeTestRule.onNodeWithText("Suggested Friends").assertExists()
+        composeTestRule.onNodeWithText("Freunde").assertIsDisplayed()
     }
 
     @Test
-    fun friendsScreen_shows_online_friend_name() {
+    fun friendsScreen_shows_search_field() {
         composeTestRule.setContent {
             SkyjoTheme {
                 FriendsScreen(onNavigate = {})
             }
         }
-        composeTestRule.onNodeWithText("KiraBlaze").assertIsDisplayed()
+        composeTestRule.onNodeWithText("User suchen").assertExists()
     }
 
-    // Each online friend has its own "Invite" button (3 total), so use onAllNodesWithText
+    @Test
+    fun friendsScreen_shows_empty_friend_state() {
+        composeTestRule.setContent {
+            SkyjoTheme {
+                FriendsScreen(onNavigate = {})
+            }
+        }
+        composeTestRule.onNodeWithText("Noch keine Freunde").assertIsDisplayed()
+    }
+
     @Test
     fun friendsScreen_shows_friend_invite_button() {
         composeTestRule.setContent {
             SkyjoTheme {
-                FriendsScreen(onNavigate = {})
+                FriendsScreen(
+                    onNavigate = {},
+                    friends = listOf(FriendDto("user-1", "FriendOne", online = true)),
+                    activeLobbyId = "lobby-1",
+                )
             }
         }
         composeTestRule.onAllNodesWithText("Invite")[0].assertExists()
     }
 
-    // Each suggested friend has a "+ Add" button (2 total) and they may be below the fold
     @Test
-    fun friendsScreen_shows_suggested_friend_add_button() {
+    fun friendsScreen_shows_search_result_add_button() {
         composeTestRule.setContent {
             SkyjoTheme {
-                FriendsScreen(onNavigate = {})
+                FriendsScreen(
+                    onNavigate = {},
+                    searchResults = listOf(SocialUserDto("user-2", "SearchUser")),
+                )
             }
         }
-        composeTestRule.onAllNodesWithText("+ Add")[0].assertExists()
+        composeTestRule.onAllNodesWithText("Add")[0].assertExists()
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/friends/FriendsScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/friends/FriendsScreenTest.kt
@@ -53,7 +53,7 @@ class FriendsScreenTest {
                 FriendsScreen(onNavigate = {})
             }
         }
-        composeTestRule.onNodeWithText("Freunde").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Your Friends").assertIsDisplayed()
     }
 
     @Test
@@ -63,7 +63,7 @@ class FriendsScreenTest {
                 FriendsScreen(onNavigate = {})
             }
         }
-        composeTestRule.onNodeWithText("User suchen").assertExists()
+        composeTestRule.onNodeWithText("Search users").assertExists()
     }
 
     @Test
@@ -73,7 +73,7 @@ class FriendsScreenTest {
                 FriendsScreen(onNavigate = {})
             }
         }
-        composeTestRule.onNodeWithText("Noch keine Freunde").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No friends yet").assertIsDisplayed()
     }
 
     @Test
@@ -132,8 +132,8 @@ class FriendsScreenTest {
                 )
             }
         }
-        composeTestRule.onNodeWithText("Anfragen").assertExists()
-        composeTestRule.onNodeWithText("Lobby Einladungen").assertExists()
+        composeTestRule.onNodeWithText("Requests").assertExists()
+        composeTestRule.onNodeWithText("Lobby Invites").assertExists()
         composeTestRule.onNodeWithText("Accept").assertExists()
         composeTestRule.onNodeWithText("Join").assertExists()
         composeTestRule.onNodeWithText("Code ABC123").assertExists()
@@ -155,9 +155,9 @@ class FriendsScreenTest {
             }
         }
         composeTestRule.onNodeWithText("Offline").assertExists()
-        composeTestRule.onNodeWithText("Freund").assertExists()
-        composeTestRule.onNodeWithText("Anfrage offen").assertExists()
-        composeTestRule.onNodeWithText("Gesendet").assertExists()
+        composeTestRule.onNodeWithText("Friend").assertExists()
+        composeTestRule.onNodeWithText("Request pending").assertExists()
+        composeTestRule.onNodeWithText("Sent").assertExists()
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/friends/FriendsScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/friends/FriendsScreenTest.kt
@@ -7,6 +7,10 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import at.aau.se2.skyjo.model.social.FriendDto
+import at.aau.se2.skyjo.model.social.FriendRequestDto
+import at.aau.se2.skyjo.model.social.FriendRequestStatus
+import at.aau.se2.skyjo.model.social.LobbyInviteDto
+import at.aau.se2.skyjo.model.social.LobbyInviteStatus
 import at.aau.se2.skyjo.model.social.SocialUserDto
 import at.aau.se2.skyjo.ui.theme.SkyjoTheme
 import org.junit.Rule
@@ -97,6 +101,63 @@ class FriendsScreenTest {
             }
         }
         composeTestRule.onAllNodesWithText("Add")[0].assertExists()
+    }
+
+    @Test
+    fun friendsScreen_shows_request_and_invite_actions() {
+        composeTestRule.setContent {
+            SkyjoTheme {
+                FriendsScreen(
+                    onNavigate = {},
+                    incomingRequests = listOf(
+                        FriendRequestDto(
+                            requestId = "request-1",
+                            from = SocialUserDto("from", "Requester"),
+                            to = SocialUserDto("to", "Me"),
+                            status = FriendRequestStatus.PENDING,
+                            createdAt = 1L,
+                        ),
+                    ),
+                    lobbyInvites = listOf(
+                        LobbyInviteDto(
+                            inviteId = "invite-1",
+                            lobbyId = "lobby-1",
+                            joinCode = "ABC123",
+                            from = SocialUserDto("from", "Requester"),
+                            to = SocialUserDto("to", "Me"),
+                            status = LobbyInviteStatus.PENDING,
+                            createdAt = 1L,
+                        ),
+                    ),
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Anfragen").assertExists()
+        composeTestRule.onNodeWithText("Lobby Einladungen").assertExists()
+        composeTestRule.onNodeWithText("Accept").assertExists()
+        composeTestRule.onNodeWithText("Join").assertExists()
+        composeTestRule.onNodeWithText("Code ABC123").assertExists()
+    }
+
+    @Test
+    fun friendsScreen_shows_friend_relationship_statuses() {
+        composeTestRule.setContent {
+            SkyjoTheme {
+                FriendsScreen(
+                    onNavigate = {},
+                    friends = listOf(FriendDto("user-1", "OfflineFriend", online = false)),
+                    searchResults = listOf(
+                        SocialUserDto("user-2", "AlreadyFriend", at.aau.se2.skyjo.model.social.RelationshipStatus.FRIENDS),
+                        SocialUserDto("user-3", "IncomingUser", at.aau.se2.skyjo.model.social.RelationshipStatus.INCOMING_REQUEST),
+                        SocialUserDto("user-4", "OutgoingUser", at.aau.se2.skyjo.model.social.RelationshipStatus.OUTGOING_REQUEST),
+                    ),
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Offline").assertExists()
+        composeTestRule.onNodeWithText("Freund").assertExists()
+        composeTestRule.onNodeWithText("Anfrage offen").assertExists()
+        composeTestRule.onNodeWithText("Gesendet").assertExists()
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/leaderboard/LeaderboardScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/leaderboard/LeaderboardScreenTest.kt
@@ -1,0 +1,60 @@
+package at.aau.se2.skyjo.ui.screens.leaderboard
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import at.aau.se2.skyjo.model.stats.LeaderboardEntryDto
+import at.aau.se2.skyjo.ui.theme.SkyjoTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class LeaderboardScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun leaderboardScreen_shows_empty_state() {
+        composeTestRule.setContent {
+            SkyjoTheme {
+                LeaderboardScreen(onNavigate = {})
+            }
+        }
+
+        composeTestRule.onAllNodesWithText("Leaderboard")[0].assertIsDisplayed()
+        composeTestRule.onNodeWithText("Noch keine Spiele im Leaderboard").assertIsDisplayed()
+    }
+
+    @Test
+    fun leaderboardScreen_shows_entries() {
+        composeTestRule.setContent {
+            SkyjoTheme {
+                LeaderboardScreen(
+                    onNavigate = {},
+                    entries = listOf(
+                        LeaderboardEntryDto(
+                            rank = 1,
+                            userId = "user-1",
+                            username = "Alice",
+                            averageScore = 7.5,
+                            wins = 3,
+                            gamesPlayed = 4,
+                            bestScore = 2,
+                            totalScore = 30,
+                        ),
+                    ),
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("#1 Alice").assertIsDisplayed()
+        composeTestRule.onNodeWithText("4 Spiele - 3 Wins").assertIsDisplayed()
+        composeTestRule.onNodeWithText("7.5").assertIsDisplayed()
+    }
+}

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/leaderboard/LeaderboardScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/leaderboard/LeaderboardScreenTest.kt
@@ -28,7 +28,7 @@ class LeaderboardScreenTest {
         }
 
         composeTestRule.onAllNodesWithText("Leaderboard")[0].assertIsDisplayed()
-        composeTestRule.onNodeWithText("Noch keine Spiele im Leaderboard").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No games on the leaderboard yet").assertIsDisplayed()
     }
 
     @Test
@@ -54,7 +54,7 @@ class LeaderboardScreenTest {
         }
 
         composeTestRule.onNodeWithText("#1 Alice").assertIsDisplayed()
-        composeTestRule.onNodeWithText("4 Spiele - 3 Wins").assertIsDisplayed()
+        composeTestRule.onNodeWithText("4 Games - 3 Wins").assertIsDisplayed()
         composeTestRule.onNodeWithText("7.5").assertIsDisplayed()
     }
 }

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/lobby/LobbyScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/lobby/LobbyScreenTest.kt
@@ -101,6 +101,41 @@ class LobbyScreenTest {
     }
 
     @Test
+    fun lobbyScreen_shows_join_code_and_error_message() {
+        composeTestRule.setContent {
+            SkyjoTheme {
+                LobbyScreen(
+                    joinCode = "ABC123",
+                    errorMessage = "Lobby konnte nicht betreten werden",
+                    onStartGame = {},
+                    onBack = {},
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Join Code: ABC123").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Lobby konnte nicht betreten werden").assertIsDisplayed()
+    }
+
+    @Test
+    fun lobbyScreen_shows_non_host_waiting_text() {
+        composeTestRule.setContent {
+            SkyjoTheme {
+                LobbyScreen(
+                    players = listOf(
+                        LobbyPlayer("Alice", isHost = true),
+                        LobbyPlayer("Bob", isHost = false),
+                    ),
+                    isHost = false,
+                    onStartGame = {},
+                    onBack = {},
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Only the host can change rules").assertExists()
+        composeTestRule.onNodeWithText("Waiting for host to start").assertExists()
+    }
+
+    @Test
     fun lobbyScreen_back_callback_works() {
         var backPressed = false
         composeTestRule.setContent {

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/lobby/LobbyScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/lobby/LobbyScreenTest.kt
@@ -106,14 +106,14 @@ class LobbyScreenTest {
             SkyjoTheme {
                 LobbyScreen(
                     joinCode = "ABC123",
-                    errorMessage = "Lobby konnte nicht betreten werden",
+                    errorMessage = "Could not join lobby",
                     onStartGame = {},
                     onBack = {},
                 )
             }
         }
         composeTestRule.onNodeWithText("Join Code: ABC123").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Lobby konnte nicht betreten werden").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Could not join lobby").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/settings/SettingsScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/settings/SettingsScreenTest.kt
@@ -57,7 +57,7 @@ class SettingsScreenTest {
                 SettingsScreen(onNavigate = {})
             }
         }
-        composeTestRule.onNodeWithText("Session sicher gespeichert").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Session securely stored").assertIsDisplayed()
     }
 
     // Items below the fold in the scrollable column use assertExists() instead of assertIsDisplayed()

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/settings/SettingsScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/settings/SettingsScreenTest.kt
@@ -40,25 +40,24 @@ class SettingsScreenTest {
         composeTestRule.onAllNodesWithText("Settings")[0].assertExists()
     }
 
-    // "AcePlayer" also appears in the always-composed drawer header, so use onAllNodesWithText
     @Test
-    fun settingsScreen_shows_player_name() {
+    fun settingsScreen_shows_account_name() {
         composeTestRule.setContent {
             SkyjoTheme {
                 SettingsScreen(onNavigate = {})
             }
         }
-        composeTestRule.onAllNodesWithText("AcePlayer")[0].assertExists()
+        composeTestRule.onAllNodesWithText("Skyjo Account")[0].assertExists()
     }
 
     @Test
-    fun settingsScreen_shows_player_level() {
+    fun settingsScreen_shows_secure_session_text() {
         composeTestRule.setContent {
             SkyjoTheme {
                 SettingsScreen(onNavigate = {})
             }
         }
-        composeTestRule.onNodeWithText("Level 42").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Session sicher gespeichert").assertIsDisplayed()
     }
 
     // Items below the fold in the scrollable column use assertExists() instead of assertIsDisplayed()
@@ -113,13 +112,13 @@ class SettingsScreenTest {
     }
 
     @Test
-    fun settingsScreen_shows_link_account_option() {
+    fun settingsScreen_shows_session_option() {
         composeTestRule.setContent {
             SkyjoTheme {
                 SettingsScreen(onNavigate = {})
             }
         }
-        composeTestRule.onNodeWithText("Link Account").assertExists()
+        composeTestRule.onNodeWithText("Session").assertExists()
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/start/StartScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/start/StartScreenTest.kt
@@ -42,7 +42,7 @@ class StartScreenTest {
                 )
             }
         }
-        composeTestRule.onNodeWithText("Bereit fuer die naechste Lobby").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Ready for the next lobby").assertIsDisplayed()
     }
 
     @Test
@@ -55,7 +55,7 @@ class StartScreenTest {
                 )
             }
         }
-        composeTestRule.onNodeWithText("LOBBY ERSTELLEN").assertExists()
+        composeTestRule.onNodeWithText("CREATE LOBBY").assertExists()
     }
 
     @Test
@@ -96,7 +96,7 @@ class StartScreenTest {
                 )
             }
         }
-        composeTestRule.onNodeWithText("Bereit fuer", substring = true).assertExists()
+        composeTestRule.onNodeWithText("Ready for", substring = true).assertExists()
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/start/StartScreenTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/screens/start/StartScreenTest.kt
@@ -1,11 +1,9 @@
 package at.aau.se2.skyjo.ui.screens.start
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import at.aau.se2.skyjo.ui.navigation.AppDestination
 import at.aau.se2.skyjo.ui.theme.SkyjoTheme
@@ -31,11 +29,11 @@ class StartScreenTest {
                 )
             }
         }
-        composeTestRule.onNodeWithText("PLAY").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Lobby").assertIsDisplayed()
     }
 
     @Test
-    fun startScreen_shows_action_mode_label() {
+    fun startScreen_shows_authenticated_player_context() {
         composeTestRule.setContent {
             SkyjoTheme {
                 StartScreen(
@@ -44,11 +42,11 @@ class StartScreenTest {
                 )
             }
         }
-        composeTestRule.onNodeWithText("ACTION MODE").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Bereit fuer die naechste Lobby").assertIsDisplayed()
     }
 
     @Test
-    fun startScreen_shows_start_session_button() {
+    fun startScreen_shows_create_lobby_button() {
         composeTestRule.setContent {
             SkyjoTheme {
                 StartScreen(
@@ -57,11 +55,11 @@ class StartScreenTest {
                 )
             }
         }
-        composeTestRule.onNodeWithText("START NEW SESSION").assertExists()
+        composeTestRule.onNodeWithText("LOBBY ERSTELLEN").assertExists()
     }
 
     @Test
-    fun startScreen_shows_name_input_field() {
+    fun startScreen_shows_join_code_input_field() {
         composeTestRule.setContent {
             SkyjoTheme {
                 StartScreen(
@@ -70,7 +68,7 @@ class StartScreenTest {
                 )
             }
         }
-        composeTestRule.onNodeWithText("Your Name").assertExists()
+        composeTestRule.onNodeWithText("Join Code").assertExists()
     }
 
     @Test
@@ -89,7 +87,7 @@ class StartScreenTest {
     }
 
     @Test
-    fun startScreen_shows_challenge_subtitle() {
+    fun startScreen_shows_lobby_subtitle() {
         composeTestRule.setContent {
             SkyjoTheme {
                 StartScreen(
@@ -98,20 +96,7 @@ class StartScreenTest {
                 )
             }
         }
-        composeTestRule.onNodeWithText("Challenge your friends", substring = true).assertExists()
-    }
-
-    @Test
-    fun startScreen_shows_online_player_count() {
-        composeTestRule.setContent {
-            SkyjoTheme {
-                StartScreen(
-                    onPlayClicked = {},
-                    onNavigate = {},
-                )
-            }
-        }
-        composeTestRule.onNodeWithText("1,284 online").assertExists()
+        composeTestRule.onNodeWithText("Bereit fuer", substring = true).assertExists()
     }
 
     @Test
@@ -124,8 +109,8 @@ class StartScreenTest {
                 )
             }
         }
-        composeTestRule.onNodeWithText("Total Wins").assertExists()
-        composeTestRule.onNodeWithText("Win Rate").assertExists()
+        composeTestRule.onNodeWithText("Wins").assertExists()
+        composeTestRule.onNodeWithText("Games").assertExists()
     }
 
     @Test
@@ -138,21 +123,7 @@ class StartScreenTest {
                 )
             }
         }
-        // "3 online" subtitle is unique to the Friends FeatureCard
-        composeTestRule.onNodeWithText("3 online").assertExists()
-    }
-
-    @Test
-    fun startScreen_shows_player_level() {
-        composeTestRule.setContent {
-            SkyjoTheme {
-                StartScreen(
-                    onPlayClicked = {},
-                    onNavigate = {},
-                )
-            }
-        }
-        composeTestRule.onNodeWithText("Level 42").assertExists()
+        composeTestRule.onAllNodesWithText("Friends")[0].assertExists()
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/AuthViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/AuthViewModelTest.kt
@@ -1,0 +1,202 @@
+package at.aau.se2.skyjo.viewmodel
+
+import android.app.Application
+import at.aau.se2.skyjo.InMemorySessionStore
+import at.aau.se2.skyjo.model.auth.AuthResponse
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.network.ApiException
+import at.aau.se2.skyjo.network.SkyjoApi
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AuthViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val application = mockk<Application>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `missing existing token finishes unauthenticated session check`() {
+        val store = InMemorySessionStore()
+        val viewModel = AuthViewModel(application, store, FakeAuthApi())
+
+        assertFalse(viewModel.state.value.isCheckingSession)
+        assertFalse(viewModel.state.value.isAuthenticated)
+    }
+
+    @Test
+    fun `valid existing token authenticates user`() {
+        val store = InMemorySessionStore("saved-token")
+        val api = FakeAuthApi(meUser = AuthUserDto("user-1", "Alice"))
+        val viewModel = AuthViewModel(application, store, api)
+
+        assertTrue(viewModel.state.value.isAuthenticated)
+        assertEquals("Alice", viewModel.state.value.username)
+        assertEquals("user-1", viewModel.state.value.user?.userId)
+    }
+
+    @Test
+    fun `invalid existing token clears local session`() {
+        val store = InMemorySessionStore("bad-token")
+        val viewModel = AuthViewModel(application, store, FakeAuthApi(meError = ApiException("expired", 401)))
+
+        assertFalse(viewModel.state.value.isAuthenticated)
+        assertNull(store.storedToken)
+        assertEquals(1, store.clearCount)
+    }
+
+    @Test
+    fun `invalid username is rejected before calling API`() {
+        val api = FakeAuthApi()
+        val viewModel = AuthViewModel(application, InMemorySessionStore(), api)
+
+        viewModel.updateUsername("x")
+        viewModel.updatePassword("SecurePass123")
+        viewModel.submit()
+
+        assertEquals(0, api.loginCalls)
+        assertTrue(viewModel.state.value.errorMessage.orEmpty().contains("Username"))
+    }
+
+    @Test
+    fun `short password is rejected before calling API`() {
+        val api = FakeAuthApi()
+        val viewModel = AuthViewModel(application, InMemorySessionStore(), api)
+
+        viewModel.updateUsername("Alice_1")
+        viewModel.updatePassword("short")
+        viewModel.submit()
+
+        assertEquals(0, api.loginCalls)
+        assertTrue(viewModel.state.value.errorMessage.orEmpty().contains("Passwort"))
+    }
+
+    @Test
+    fun `login success stores token and authenticated user`() {
+        val store = InMemorySessionStore()
+        val api = FakeAuthApi(authResponse = AuthResponse("token-1", AuthUserDto("user-1", "Alice")))
+        val viewModel = AuthViewModel(application, store, api)
+
+        viewModel.updateUsername(" Alice ")
+        viewModel.updatePassword("SecurePass123")
+        viewModel.submit()
+
+        assertEquals(1, api.loginCalls)
+        assertEquals("Alice", api.lastUsername)
+        assertEquals("token-1", store.storedToken)
+        assertTrue(viewModel.state.value.isAuthenticated)
+        assertEquals("", viewModel.state.value.password)
+    }
+
+    @Test
+    fun `register mode calls register endpoint`() {
+        val api = FakeAuthApi(authResponse = AuthResponse("token-2", AuthUserDto("user-2", "Bob")))
+        val viewModel = AuthViewModel(application, InMemorySessionStore(), api)
+
+        viewModel.toggleMode()
+        viewModel.updateUsername("Bob_1")
+        viewModel.updatePassword("SecurePass123")
+        viewModel.submit()
+
+        assertEquals(1, api.registerCalls)
+        assertEquals(0, api.loginCalls)
+        assertTrue(viewModel.state.value.isAuthenticated)
+    }
+
+    @Test
+    fun `login failure exposes readable API message`() {
+        val api = FakeAuthApi(loginError = ApiException("Invalid username or password", 401))
+        val viewModel = AuthViewModel(application, InMemorySessionStore(), api)
+
+        viewModel.updateUsername("Alice")
+        viewModel.updatePassword("SecurePass123")
+        viewModel.submit()
+
+        assertFalse(viewModel.state.value.isSubmitting)
+        assertEquals("Invalid username or password", viewModel.state.value.errorMessage)
+    }
+
+    @Test
+    fun `toggle mode clears password and update clears error`() {
+        val viewModel = AuthViewModel(application, InMemorySessionStore(), FakeAuthApi())
+
+        viewModel.updateUsername("x")
+        viewModel.updatePassword("bad")
+        viewModel.submit()
+        assertTrue(viewModel.state.value.errorMessage != null)
+
+        viewModel.updateUsername("Alice")
+        assertNull(viewModel.state.value.errorMessage)
+        viewModel.updatePassword("SecurePass123")
+        viewModel.toggleMode()
+
+        assertTrue(viewModel.state.value.isRegisterMode)
+        assertEquals("", viewModel.state.value.password)
+    }
+
+    @Test
+    fun `logout clears token even when API logout fails`() {
+        val store = InMemorySessionStore("token")
+        val api = FakeAuthApi(logoutError = ApiException("gone", 401))
+        val viewModel = AuthViewModel(application, store, api)
+
+        viewModel.logout()
+
+        assertNull(store.storedToken)
+        assertFalse(viewModel.state.value.isAuthenticated)
+        assertFalse(viewModel.state.value.isCheckingSession)
+    }
+
+    private class FakeAuthApi(
+        private val meUser: AuthUserDto = AuthUserDto("user", "Existing"),
+        private val meError: Throwable? = null,
+        private val authResponse: AuthResponse = AuthResponse("token", AuthUserDto("user", "Alice")),
+        private val loginError: Throwable? = null,
+        private val logoutError: Throwable? = null,
+    ) : SkyjoApi {
+        var loginCalls = 0
+        var registerCalls = 0
+        var lastUsername: String? = null
+
+        override suspend fun me(): AuthUserDto {
+            meError?.let { throw it }
+            return meUser
+        }
+
+        override suspend fun login(username: String, password: String): AuthResponse {
+            loginCalls++
+            lastUsername = username
+            loginError?.let { throw it }
+            return authResponse
+        }
+
+        override suspend fun register(username: String, password: String): AuthResponse {
+            registerCalls++
+            lastUsername = username
+            return authResponse
+        }
+
+        override suspend fun logout() {
+            logoutError?.let { throw it }
+        }
+    }
+}

--- a/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/AuthViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/AuthViewModelTest.kt
@@ -87,7 +87,7 @@ class AuthViewModelTest {
         viewModel.submit()
 
         assertEquals(0, api.loginCalls)
-        assertTrue(viewModel.state.value.errorMessage.orEmpty().contains("Passwort"))
+        assertTrue(viewModel.state.value.errorMessage.orEmpty().contains("Password"))
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/FriendsViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/FriendsViewModelTest.kt
@@ -1,0 +1,243 @@
+package at.aau.se2.skyjo.viewmodel
+
+import android.app.Application
+import at.aau.se2.skyjo.model.social.FriendDto
+import at.aau.se2.skyjo.model.social.FriendRequestDto
+import at.aau.se2.skyjo.model.social.FriendRequestStatus
+import at.aau.se2.skyjo.model.social.FriendRequestsResponse
+import at.aau.se2.skyjo.model.social.LobbyInviteDto
+import at.aau.se2.skyjo.model.social.LobbyInviteStatus
+import at.aau.se2.skyjo.model.social.SocialUserDto
+import at.aau.se2.skyjo.network.ApiException
+import at.aau.se2.skyjo.network.SkyjoApi
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class FriendsViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val application = mockk<Application>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `refresh loads friends requests and lobby invites`() {
+        val api = FakeFriendsApi()
+        val viewModel = FriendsViewModel(application, api)
+
+        viewModel.refresh()
+
+        assertEquals(listOf(friend), viewModel.state.value.friends)
+        assertEquals(listOf(request), viewModel.state.value.incomingRequests)
+        assertEquals(listOf(invite), viewModel.state.value.lobbyInvites)
+        assertEquals(false, viewModel.state.value.isLoading)
+    }
+
+    @Test
+    fun `refresh failure records error and stops loading`() {
+        val viewModel = FriendsViewModel(application, FakeFriendsApi(refreshError = ApiException("offline")))
+
+        viewModel.refresh()
+
+        assertEquals("offline", viewModel.state.value.errorMessage)
+        assertEquals(false, viewModel.state.value.isLoading)
+    }
+
+    @Test
+    fun `short search query clears results without API call`() {
+        val api = FakeFriendsApi()
+        val viewModel = FriendsViewModel(application, api)
+
+        viewModel.updateSearch("a")
+
+        assertEquals("a", viewModel.state.value.query)
+        assertTrue(viewModel.state.value.searchResults.isEmpty())
+        assertEquals(0, api.searchCalls)
+    }
+
+    @Test
+    fun `search query loads users`() {
+        val api = FakeFriendsApi()
+        val viewModel = FriendsViewModel(application, api)
+
+        viewModel.updateSearch("ali")
+
+        assertEquals(1, api.searchCalls)
+        assertEquals(listOf(searchUser), viewModel.state.value.searchResults)
+    }
+
+    @Test
+    fun `friend request actions refresh state on success`() {
+        val api = FakeFriendsApi()
+        val viewModel = FriendsViewModel(application, api)
+
+        viewModel.sendFriendRequest("to-user")
+        viewModel.acceptRequest("request-1")
+        viewModel.declineRequest("request-2")
+
+        assertEquals(1, api.sendRequestCalls)
+        assertEquals(1, api.acceptCalls)
+        assertEquals(1, api.declineCalls)
+        assertEquals(3, api.refreshCalls)
+    }
+
+    @Test
+    fun `friend request failure stores error`() {
+        val viewModel = FriendsViewModel(application, FakeFriendsApi(sendRequestError = ApiException("duplicate")))
+
+        viewModel.sendFriendRequest("to-user")
+
+        assertEquals("duplicate", viewModel.state.value.errorMessage)
+    }
+
+    @Test
+    fun `invite friend requires active lobby`() {
+        val api = FakeFriendsApi()
+        val viewModel = FriendsViewModel(application, api)
+
+        viewModel.inviteFriend(null, "friend-1")
+        viewModel.inviteFriend("lobby-1", "friend-1")
+
+        assertEquals(1, api.inviteCalls)
+        assertEquals("lobby-1", api.lastLobbyId)
+    }
+
+    @Test
+    fun `invite friend failure stores error`() {
+        val viewModel = FriendsViewModel(application, FakeFriendsApi(inviteError = ApiException("not friends")))
+
+        viewModel.inviteFriend("lobby-1", "friend-1")
+
+        assertEquals("not friends", viewModel.state.value.errorMessage)
+    }
+
+    @Test
+    fun `add lobby invite replaces duplicate and remove deletes invite`() {
+        val viewModel = FriendsViewModel(application, FakeFriendsApi())
+
+        viewModel.addLobbyInvite(invite.copy(joinCode = "AAA111"))
+        viewModel.addLobbyInvite(invite.copy(joinCode = "BBB222"))
+        viewModel.removeLobbyInvite(invite.inviteId)
+
+        assertTrue(viewModel.state.value.lobbyInvites.isEmpty())
+    }
+
+    @Test
+    fun `decline lobby invite removes invite on success`() {
+        val api = FakeFriendsApi()
+        val viewModel = FriendsViewModel(application, api)
+        viewModel.addLobbyInvite(invite)
+
+        viewModel.declineLobbyInvite(invite.inviteId)
+
+        assertEquals(1, api.declineInviteCalls)
+        assertTrue(viewModel.state.value.lobbyInvites.isEmpty())
+    }
+
+    @Test
+    fun `decline lobby invite failure keeps error`() {
+        val viewModel = FriendsViewModel(application, FakeFriendsApi(declineInviteError = ApiException("missing")))
+
+        viewModel.declineLobbyInvite(invite.inviteId)
+
+        assertEquals("missing", viewModel.state.value.errorMessage)
+    }
+
+    private class FakeFriendsApi(
+        private val refreshError: Throwable? = null,
+        private val sendRequestError: Throwable? = null,
+        private val inviteError: Throwable? = null,
+        private val declineInviteError: Throwable? = null,
+    ) : SkyjoApi {
+        var refreshCalls = 0
+        var searchCalls = 0
+        var sendRequestCalls = 0
+        var acceptCalls = 0
+        var declineCalls = 0
+        var inviteCalls = 0
+        var declineInviteCalls = 0
+        var lastLobbyId: String? = null
+
+        override suspend fun friends(): List<FriendDto> {
+            refreshCalls++
+            refreshError?.let { throw it }
+            return listOf(friend)
+        }
+
+        override suspend fun friendRequests(): FriendRequestsResponse =
+            FriendRequestsResponse(incoming = listOf(request), outgoing = emptyList())
+
+        override suspend fun lobbyInvites(): List<LobbyInviteDto> = listOf(invite)
+
+        override suspend fun searchUsers(query: String): List<SocialUserDto> {
+            searchCalls++
+            return listOf(searchUser)
+        }
+
+        override suspend fun sendFriendRequest(toUserId: String): FriendRequestDto {
+            sendRequestCalls++
+            sendRequestError?.let { throw it }
+            return request
+        }
+
+        override suspend fun acceptFriendRequest(requestId: String): FriendRequestDto {
+            acceptCalls++
+            return request.copy(status = FriendRequestStatus.ACCEPTED)
+        }
+
+        override suspend fun declineFriendRequest(requestId: String): FriendRequestDto {
+            declineCalls++
+            return request.copy(status = FriendRequestStatus.DECLINED)
+        }
+
+        override suspend fun sendLobbyInvite(lobbyId: String, toUserId: String): LobbyInviteDto {
+            inviteCalls++
+            lastLobbyId = lobbyId
+            inviteError?.let { throw it }
+            return invite
+        }
+
+        override suspend fun declineLobbyInvite(inviteId: String): LobbyInviteDto {
+            declineInviteCalls++
+            declineInviteError?.let { throw it }
+            return invite.copy(status = LobbyInviteStatus.DECLINED)
+        }
+    }
+
+    private companion object {
+        val friend = FriendDto("friend-1", "FriendOne", online = true, currentLobbyId = "lobby-1")
+        val searchUser = SocialUserDto("search-1", "SearchOne")
+        val request = FriendRequestDto(
+            requestId = "request-1",
+            from = searchUser,
+            to = SocialUserDto("me", "Me"),
+            status = FriendRequestStatus.PENDING,
+            createdAt = 10L,
+        )
+        val invite = LobbyInviteDto(
+            inviteId = "invite-1",
+            lobbyId = "lobby-1",
+            joinCode = "ABC123",
+            from = searchUser,
+            to = SocialUserDto("me", "Me"),
+            status = LobbyInviteStatus.PENDING,
+            createdAt = 20L,
+        )
+    }
+}

--- a/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
@@ -203,6 +203,21 @@ class GameViewModelTest {
     }
 
     @Test
+    fun `isHost is true when player is not first but has isHost flag set to true`() {
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        viewModel.connect("Bob")
+        fakeLobbyState.value = LobbyUpdateMessage(
+            players = listOf(
+                LobbyPlayer("Alice", isHost = false),
+                LobbyPlayer("Bob", isHost = true),
+            ),
+            status = "WAITING",
+            maxPlayers = 6,
+        )
+        assertTrue(viewModel.isHost.value)
+    }
+
+    @Test
     fun `leaveLobby delegates to client`() {
         val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.leaveLobby()
@@ -484,6 +499,32 @@ class GameViewModelTest {
         fakeIsConnected.value = false
 
         coVerify(exactly = 0) { mockApi.createWebSocketTicket() }
+    }
+
+    @Test
+    fun `authenticated reconnect fetches and applies current lobby state`() {
+        coEvery { mockApi.currentLobby() } returns lobbySummary()
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        viewModel.connect("Alice")
+
+        fakeIsConnected.value = true
+        fakeIsConnected.value = false
+
+        coVerify(atLeast = 1) { mockApi.currentLobby() }
+        verify(atLeast = 1) { mockGameClient.applyLobbyState(expectedLobbyUpdate()) }
+    }
+
+    @Test
+    fun `authenticated reconnect skips applying lobby state when currentLobby returns null`() {
+        coEvery { mockApi.currentLobby() } returns null
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        viewModel.connect("Alice")
+
+        fakeIsConnected.value = true
+        fakeIsConnected.value = false
+
+        coVerify(atLeast = 1) { mockApi.currentLobby() }
+        verify(exactly = 0) { mockGameClient.applyLobbyState(any()) }
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
@@ -13,14 +13,16 @@ import at.aau.se2.skyjo.model.LobbyPlayer
 import at.aau.se2.skyjo.model.LobbyUpdateMessage
 import at.aau.se2.skyjo.model.PlayActionCardCommand
 import at.aau.se2.skyjo.model.TotalScore
-import at.aau.se2.skyjo.network.GameStompClient
+import at.aau.se2.skyjo.model.auth.WsTicketResponse
+import at.aau.se2.skyjo.model.social.LobbyInviteDto
+import at.aau.se2.skyjo.network.GameRealtimeClient
+import at.aau.se2.skyjo.network.SkyjoApi
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkConstructor
 import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
@@ -40,10 +42,13 @@ class GameViewModelTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private val mockApplication = mockk<Application>(relaxed = true)
+    private val mockApi = mockk<SkyjoApi>(relaxed = true)
+    private val mockGameClient = mockk<GameRealtimeClient>(relaxed = true)
 
     private val fakeLobbyState = MutableStateFlow<LobbyUpdateMessage?>(null)
     private val fakeGameState = MutableStateFlow<GameUpdateMessage?>(null)
     private val fakeActionCardResults = MutableSharedFlow<ActionCardResultMessage>()
+    private val fakeIncomingInvites = MutableSharedFlow<LobbyInviteDto>()
     private val fakeErrorMessage = MutableSharedFlow<String>()
     private val fakeConnectionError = MutableStateFlow<String?>(null)
     private val fakeIsConnected = MutableStateFlow(false)
@@ -58,25 +63,27 @@ class GameViewModelTest {
         fakeIsConnected.value = false
         fakeHasRejoinedGame.value = false
 
-        mockkConstructor(GameStompClient::class)
+        every { mockGameClient.lobbyState } returns fakeLobbyState
+        every { mockGameClient.gameState } returns fakeGameState
+        every { mockGameClient.actionCardResults } returns fakeActionCardResults
+        every { mockGameClient.incomingInvites } returns fakeIncomingInvites
+        every { mockGameClient.errorMessage } returns fakeErrorMessage
+        every { mockGameClient.connectionError } returns fakeConnectionError
+        every { mockGameClient.isConnected } returns fakeIsConnected
+        every { mockGameClient.hasRejoinedGame } returns fakeHasRejoinedGame
 
-        every { anyConstructed<GameStompClient>().lobbyState } returns fakeLobbyState
-        every { anyConstructed<GameStompClient>().gameState } returns fakeGameState
-        every { anyConstructed<GameStompClient>().actionCardResults } returns fakeActionCardResults
-        every { anyConstructed<GameStompClient>().errorMessage } returns fakeErrorMessage
-        every { anyConstructed<GameStompClient>().connectionError } returns fakeConnectionError
-        every { anyConstructed<GameStompClient>().isConnected } returns fakeIsConnected
-        every { anyConstructed<GameStompClient>().hasRejoinedGame } returns fakeHasRejoinedGame
-
-        coEvery { anyConstructed<GameStompClient>().connect() } just runs
-        coEvery { anyConstructed<GameStompClient>().reconnect(any()) } just runs
-        every { anyConstructed<GameStompClient>().joinLobby(any(), any()) } just runs
-        every { anyConstructed<GameStompClient>().leaveLobby() } just runs
-        every { anyConstructed<GameStompClient>().startGame(any(), any()) } just runs
-        every { anyConstructed<GameStompClient>().sendAction(any()) } just runs
-        every { anyConstructed<GameStompClient>().playActionCard(any()) } just runs
-        every { anyConstructed<GameStompClient>().disconnect() } just runs
-        every { anyConstructed<GameStompClient>().close() } just runs
+        coEvery { mockGameClient.connect() } just runs
+        coEvery { mockGameClient.connect(any(), any()) } just runs
+        coEvery { mockGameClient.reconnect(any()) } just runs
+        coEvery { mockApi.createWebSocketTicket() } returns WsTicketResponse("ticket", Long.MAX_VALUE)
+        every { mockGameClient.joinLobby(any(), any()) } just runs
+        every { mockGameClient.leaveLobby() } just runs
+        every { mockGameClient.startGame(any(), any()) } just runs
+        every { mockGameClient.sendAction(any()) } just runs
+        every { mockGameClient.playActionCard(any()) } just runs
+        every { mockGameClient.clearStoredGame() } just runs
+        every { mockGameClient.disconnect() } just runs
+        every { mockGameClient.close() } just runs
     }
 
     @After
@@ -87,26 +94,26 @@ class GameViewModelTest {
 
     @Test
     fun `init does not connect automatically`() {
-        GameViewModel(mockApplication)
-        verify(exactly = 0) { anyConstructed<GameStompClient>().joinLobby(any(), any()) }
+        GameViewModel(mockApplication, mockApi, mockGameClient)
+        verify(exactly = 0) { mockGameClient.joinLobby(any(), any()) }
     }
 
     @Test
     fun `myPlayerName is empty initially`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         assertEquals("", viewModel.myPlayerName.value)
     }
 
     @Test
     fun `connect sets playerName`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.connect("TestPlayer")
         assertEquals("TestPlayer", viewModel.myPlayerName.value)
     }
 
     @Test
     fun `myPlayerId resolves connected player from game state`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.connect("Alice")
 
         fakeGameState.value = makeGameState(currentPlayerId = "p2")
@@ -117,7 +124,7 @@ class GameViewModelTest {
 
     @Test
     fun `isMyTurn is true when current player matches resolved player id`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.connect("Alice")
 
         fakeGameState.value = makeGameState(currentPlayerId = "p1")
@@ -128,13 +135,13 @@ class GameViewModelTest {
 
     @Test
     fun `isHost is false when lobby is empty`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         assertFalse(viewModel.isHost.value)
     }
 
     @Test
     fun `isHost is true when player is first in lobby`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.connect("Alice")
         fakeLobbyState.value = LobbyUpdateMessage(
             players = listOf(LobbyPlayer("Alice", isHost = true)),
@@ -146,7 +153,7 @@ class GameViewModelTest {
 
     @Test
     fun `isHost is false when player is not host`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.connect("Bob")
         fakeLobbyState.value = LobbyUpdateMessage(
             players = listOf(
@@ -161,32 +168,32 @@ class GameViewModelTest {
 
     @Test
     fun `leaveLobby delegates to client`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.leaveLobby()
-        verify(exactly = 1) { anyConstructed<GameStompClient>().leaveLobby() }
-        verify(exactly = 1) { anyConstructed<GameStompClient>().disconnect() }
+        verify(exactly = 1) { mockGameClient.leaveLobby() }
+        verify(exactly = 1) { mockGameClient.disconnect() }
     }
 
     @Test
     fun `startGame delegates to client with correct params`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.startGame(maxRounds = 5, targetScore = 100)
-        verify(exactly = 1) { anyConstructed<GameStompClient>().startGame(5, 100) }
+        verify(exactly = 1) { mockGameClient.startGame(5, 100) }
     }
 
     @Test
     fun `startGame with default params uses correct defaults`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.startGame()
-        verify(exactly = 1) { anyConstructed<GameStompClient>().startGame(3, 100) }
+        verify(exactly = 1) { mockGameClient.startGame(3, 100) }
     }
 
     @Test
     fun `drawFromDeck sends DRAW DECK action`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.drawFromDeck()
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 GameAction(type = "DRAW", source = "DECK")
             )
         }
@@ -194,10 +201,10 @@ class GameViewModelTest {
 
     @Test
     fun `drawFromDiscard sends DRAW DISCARD action`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.drawFromDiscard()
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 GameAction(type = "DRAW", source = "DISCARD")
             )
         }
@@ -205,10 +212,10 @@ class GameViewModelTest {
 
     @Test
     fun `replaceCard sends REPLACE action with correct coordinates`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.replaceCard(row = 1, col = 2)
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 GameAction(type = "REPLACE", row = 1, col = 2)
             )
         }
@@ -216,10 +223,10 @@ class GameViewModelTest {
 
     @Test
     fun `discardAndReveal sends DISCARD_AND_REVEAL action`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.discardAndReveal(row = 0, col = 3)
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 GameAction(type = "DISCARD_AND_REVEAL", row = 0, col = 3)
             )
         }
@@ -227,10 +234,10 @@ class GameViewModelTest {
 
     @Test
     fun `drawFromActionDeck sends DRAW ACTION_DECK action`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.drawFromActionDeck()
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 GameAction(type = "DRAW", source = "ACTION_DECK")
             )
         }
@@ -238,10 +245,10 @@ class GameViewModelTest {
 
     @Test
     fun `drawVisibleActionCard sends DRAW_VISIBLE_ACTION_CARD action`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.drawVisibleActionCard(actionCardIndex = 2)
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 GameAction(type = "DRAW_VISIBLE_ACTION_CARD", actionCardIndex = 2)
             )
         }
@@ -249,10 +256,10 @@ class GameViewModelTest {
 
     @Test
     fun `playActionCard sends PLAY_ACTION_CARD action`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.playActionCard(actionCardIndex = 1)
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 GameAction(type = "PLAY_ACTION_CARD", actionCardIndex = 1)
             )
         }
@@ -268,18 +275,18 @@ class GameViewModelTest {
                 lineIndex = 0,
             ),
         )
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
 
         viewModel.playActionCard(command)
 
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().playActionCard(command)
+            mockGameClient.playActionCard(command)
         }
     }
 
     @Test
     fun `playEnlightenment builds board line target command`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
 
         viewModel.playEnlightenment(
             actionCardIndex = 2,
@@ -289,7 +296,7 @@ class GameViewModelTest {
         )
 
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().playActionCard(
+            mockGameClient.playActionCard(
                 PlayActionCardCommand(
                     actionCardIndex = 2,
                     parameters = ActionCardParameters.BoardLineTarget(
@@ -304,55 +311,56 @@ class GameViewModelTest {
 
     @Test
     fun `discardActionCard sends DISCARD_ACTION_CARD action`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.discardActionCard(actionCardIndex = 0)
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 GameAction(type = "DISCARD_ACTION_CARD", actionCardIndex = 0)
             )
         }
     }
 
     @Test
-    fun `reconnect is triggered when connection drops with player name set`() {
-        val viewModel = GameViewModel(mockApplication)
+    fun `authenticated reconnect is triggered when connection drops with player name set`() {
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.connect("Alice")
 
         fakeIsConnected.value = true
         fakeIsConnected.value = false
 
-        coVerify(atLeast = 1) { anyConstructed<GameStompClient>().reconnect("Alice") }
+        coVerify(atLeast = 1) { mockApi.createWebSocketTicket() }
+        coVerify(atLeast = 1) { mockGameClient.connect("ticket", any()) }
     }
 
     @Test
-    fun `reconnect is not triggered when player name is empty`() {
-        GameViewModel(mockApplication)
+    fun `authenticated reconnect is not triggered when player name is empty`() {
+        GameViewModel(mockApplication, mockApi, mockGameClient)
 
         fakeIsConnected.value = true
         fakeIsConnected.value = false
 
-        coVerify(exactly = 0) { anyConstructed<GameStompClient>().reconnect(any()) }
+        coVerify(exactly = 0) { mockApi.createWebSocketTicket() }
     }
 
     @Test
     fun `onCleared calls close`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         val method = GameViewModel::class.java.getDeclaredMethod("onCleared")
         method.isAccessible = true
         method.invoke(viewModel)
-        verify(exactly = 1) { anyConstructed<GameStompClient>().close() }
+        verify(exactly = 1) { mockGameClient.close() }
     }
 
     @Test
     fun `playPlayerSwapCard sends PLAY_ACTION_CARD action with all swap fields`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.playPlayerSwapCard(
             actionCardIndex = 0,
             player1Id = "p1", player1Row = 1, player1Col = 2,
             player2Id = "p2", player2Row = 0, player2Col = 3,
         )
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 GameAction(
                     type = "PLAY_ACTION_CARD",
                     actionCardIndex = 0,
@@ -369,7 +377,7 @@ class GameViewModelTest {
 
     @Test
     fun `playSwapOwnCards sends PLAY_ACTION_CARD action with own swap coordinates`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
 
         viewModel.playSwapOwnCards(
             actionCardIndex = 2,
@@ -380,7 +388,7 @@ class GameViewModelTest {
         )
 
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 GameAction(
                     type = "PLAY_ACTION_CARD",
                     actionCardIndex = 2,
@@ -395,10 +403,10 @@ class GameViewModelTest {
 
     @Test
     fun `discardActionCard sends DISCARD_ACTION_CARD action with correct index`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.discardActionCard(actionCardIndex = 2)
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 GameAction(type = "DISCARD_ACTION_CARD", actionCardIndex = 2)
             )
         }
@@ -406,14 +414,14 @@ class GameViewModelTest {
 
     @Test
     fun `playPlayerSwapCard with same player IDs still sends action (backend validates same-player rule)`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.playPlayerSwapCard(
             actionCardIndex = 1,
             player1Id = "p1", player1Row = 0, player1Col = 0,
             player2Id = "p1", player2Row = 0, player2Col = 1,
         )
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 GameAction(
                     type = "PLAY_ACTION_CARD",
                     actionCardIndex = 1,
@@ -430,10 +438,10 @@ class GameViewModelTest {
 
     @Test
     fun `discardActionCard with index zero sends correct action`() {
-        val viewModel = GameViewModel(mockApplication)
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.discardActionCard(actionCardIndex = 0)
         verify(exactly = 1) {
-            anyConstructed<GameStompClient>().sendAction(
+            mockGameClient.sendAction(
                 GameAction(type = "DISCARD_ACTION_CARD", actionCardIndex = 0)
             )
         }

--- a/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
@@ -14,7 +14,11 @@ import at.aau.se2.skyjo.model.LobbyUpdateMessage
 import at.aau.se2.skyjo.model.PlayActionCardCommand
 import at.aau.se2.skyjo.model.TotalScore
 import at.aau.se2.skyjo.model.auth.WsTicketResponse
+import at.aau.se2.skyjo.model.lobby.LobbySummaryResponse
 import at.aau.se2.skyjo.model.social.LobbyInviteDto
+import at.aau.se2.skyjo.model.social.LobbyInviteStatus
+import at.aau.se2.skyjo.model.social.SocialUserDto
+import at.aau.se2.skyjo.model.stats.PlayerStatsDto
 import at.aau.se2.skyjo.network.GameRealtimeClient
 import at.aau.se2.skyjo.network.SkyjoApi
 import io.mockk.clearAllMocks
@@ -77,6 +81,7 @@ class GameViewModelTest {
         coEvery { mockGameClient.reconnect(any()) } just runs
         coEvery { mockApi.createWebSocketTicket() } returns WsTicketResponse("ticket", Long.MAX_VALUE)
         every { mockGameClient.joinLobby(any(), any()) } just runs
+        every { mockGameClient.applyLobbyState(any()) } just runs
         every { mockGameClient.leaveLobby() } just runs
         every { mockGameClient.startGame(any(), any()) } just runs
         every { mockGameClient.sendAction(any()) } just runs
@@ -109,6 +114,37 @@ class GameViewModelTest {
         val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
         viewModel.connect("TestPlayer")
         assertEquals("TestPlayer", viewModel.myPlayerName.value)
+    }
+
+    @Test
+    fun `setAuthenticatedUsername stores current player name`() {
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+
+        viewModel.setAuthenticatedUsername("Alice")
+
+        assertEquals("Alice", viewModel.myPlayerName.value)
+    }
+
+    @Test
+    fun `refreshHomeStats stores returned stats`() {
+        coEvery { mockApi.myStats() } returns stats(username = "Alice")
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+
+        viewModel.refreshHomeStats()
+
+        assertEquals("Alice", viewModel.homeStats.value?.username)
+    }
+
+    @Test
+    fun `refreshHomeStats keeps previous stats when request fails`() {
+        coEvery { mockApi.myStats() } returns stats(username = "Alice")
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        viewModel.refreshHomeStats()
+        coEvery { mockApi.myStats() } throws IllegalStateException("offline")
+
+        viewModel.refreshHomeStats()
+
+        assertEquals("Alice", viewModel.homeStats.value?.username)
     }
 
     @Test
@@ -172,6 +208,114 @@ class GameViewModelTest {
         viewModel.leaveLobby()
         verify(exactly = 1) { mockGameClient.leaveLobby() }
         verify(exactly = 1) { mockGameClient.disconnect() }
+    }
+
+    @Test
+    fun `leaveLobby calls rest endpoint when authenticated lobby is active`() {
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        fakeLobbyState.value = LobbyUpdateMessage(
+            lobbyId = "lobby-1",
+            joinCode = "ABC123",
+            players = listOf(LobbyPlayer("Alice", isHost = true)),
+            status = "WAITING",
+            maxPlayers = 6,
+        )
+        coEvery { mockApi.leaveLobby("lobby-1") } returns lobbySummary(players = listOf(LobbyPlayer("Bob", false)))
+
+        viewModel.leaveLobby()
+
+        coVerify(exactly = 1) { mockApi.leaveLobby("lobby-1") }
+        verify(exactly = 0) { mockGameClient.leaveLobby() }
+        verify(exactly = 1) { mockGameClient.clearStoredGame() }
+        verify(exactly = 1) { mockGameClient.disconnect() }
+        assertEquals("", viewModel.myPlayerName.value)
+    }
+
+    @Test
+    fun `createLobby connects with ticket and applies lobby state`() {
+        coEvery { mockApi.createLobby() } returns lobbySummary()
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+
+        viewModel.createLobby("Alice")
+
+        assertEquals("Alice", viewModel.myPlayerName.value)
+        assertEquals(null, viewModel.lobbyError.value)
+        coVerify(exactly = 1) { mockApi.createLobby() }
+        coVerify(exactly = 1) { mockApi.createWebSocketTicket() }
+        coVerify(exactly = 1) { mockGameClient.connect("ticket", "ABC123") }
+        verify(exactly = 1) { mockGameClient.applyLobbyState(expectedLobbyUpdate()) }
+    }
+
+    @Test
+    fun `createLobby stores readable error on failure`() {
+        coEvery { mockApi.createLobby() } throws IllegalStateException("user is already in a lobby")
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+
+        viewModel.createLobby("Alice")
+
+        assertEquals("user is already in a lobby", viewModel.lobbyError.value)
+        coVerify(exactly = 0) { mockGameClient.connect(any(), any()) }
+        verify(exactly = 0) { mockGameClient.applyLobbyState(any()) }
+    }
+
+    @Test
+    fun `joinLobbyByCode connects with returned join code and applies lobby state`() {
+        coEvery { mockApi.joinLobby("abc123") } returns lobbySummary()
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+
+        viewModel.joinLobbyByCode("Alice", "abc123")
+
+        assertEquals("Alice", viewModel.myPlayerName.value)
+        coVerify(exactly = 1) { mockApi.joinLobby("abc123") }
+        coVerify(exactly = 1) { mockGameClient.connect("ticket", "ABC123") }
+        verify(exactly = 1) { mockGameClient.applyLobbyState(expectedLobbyUpdate()) }
+    }
+
+    @Test
+    fun `joinLobbyByCode stores fallback error when exception has no message`() {
+        coEvery { mockApi.joinLobby("bad") } throws object : RuntimeException() {}
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+
+        viewModel.joinLobbyByCode("Alice", "bad")
+
+        assertEquals("Lobby konnte nicht betreten werden", viewModel.lobbyError.value)
+    }
+
+    @Test
+    fun `acceptLobbyInvite connects and applies current lobby when available`() {
+        coEvery { mockApi.acceptLobbyInvite("invite-1") } returns lobbyInvite()
+        coEvery { mockApi.currentLobby() } returns lobbySummary()
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+
+        viewModel.acceptLobbyInvite("Alice", "invite-1")
+
+        assertEquals("Alice", viewModel.myPlayerName.value)
+        coVerify(exactly = 1) { mockApi.acceptLobbyInvite("invite-1") }
+        coVerify(exactly = 1) { mockApi.currentLobby() }
+        coVerify(exactly = 1) { mockGameClient.connect("ticket", "ABC123") }
+        verify(exactly = 1) { mockGameClient.applyLobbyState(expectedLobbyUpdate()) }
+    }
+
+    @Test
+    fun `acceptLobbyInvite skips lobby state when current lobby is missing`() {
+        coEvery { mockApi.acceptLobbyInvite("invite-1") } returns lobbyInvite()
+        coEvery { mockApi.currentLobby() } returns null
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+
+        viewModel.acceptLobbyInvite("Alice", "invite-1")
+
+        coVerify(exactly = 1) { mockGameClient.connect("ticket", "ABC123") }
+        verify(exactly = 0) { mockGameClient.applyLobbyState(any()) }
+    }
+
+    @Test
+    fun `acceptLobbyInvite stores fallback error when request fails without message`() {
+        coEvery { mockApi.acceptLobbyInvite("invite-1") } throws object : RuntimeException() {}
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+
+        viewModel.acceptLobbyInvite("Alice", "invite-1")
+
+        assertEquals("Einladung konnte nicht angenommen werden", viewModel.lobbyError.value)
     }
 
     @Test
@@ -446,6 +590,54 @@ class GameViewModelTest {
             )
         }
     }
+
+    private fun lobbySummary(
+        lobbyId: String = "lobby-1",
+        joinCode: String = "ABC123",
+        players: List<LobbyPlayer> = listOf(LobbyPlayer("Alice", isHost = true)),
+        status: String = "WAITING",
+        maxPlayers: Int = 6,
+    ) = LobbySummaryResponse(
+        lobbyId = lobbyId,
+        joinCode = joinCode,
+        players = players,
+        status = status,
+        maxPlayers = maxPlayers,
+    )
+
+    private fun expectedLobbyUpdate(
+        lobbyId: String = "lobby-1",
+        joinCode: String = "ABC123",
+        players: List<LobbyPlayer> = listOf(LobbyPlayer("Alice", isHost = true)),
+        status: String = "WAITING",
+        maxPlayers: Int = 6,
+    ) = LobbyUpdateMessage(
+        lobbyId = lobbyId,
+        joinCode = joinCode,
+        players = players,
+        status = status,
+        maxPlayers = maxPlayers,
+    )
+
+    private fun lobbyInvite() = LobbyInviteDto(
+        inviteId = "invite-1",
+        lobbyId = "lobby-1",
+        joinCode = "ABC123",
+        from = SocialUserDto("user-b", "Bob"),
+        to = SocialUserDto("user-a", "Alice"),
+        status = LobbyInviteStatus.PENDING,
+        createdAt = 1_000L,
+    )
+
+    private fun stats(username: String) = PlayerStatsDto(
+        userId = "user-a",
+        username = username,
+        gamesPlayed = 3,
+        wins = 1,
+        totalScore = 42,
+        bestScore = 10,
+        averageScore = 14.0,
+    )
 
     private fun makeGameState(currentPlayerId: String?) = GameUpdateMessage(
         phase = "AWAITING_DRAW",

--- a/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
@@ -293,7 +293,7 @@ class GameViewModelTest {
 
         viewModel.joinLobbyByCode("Alice", "bad")
 
-        assertEquals("Lobby konnte nicht betreten werden", viewModel.lobbyError.value)
+        assertEquals("Could not join lobby", viewModel.lobbyError.value)
     }
 
     @Test
@@ -330,7 +330,7 @@ class GameViewModelTest {
 
         viewModel.acceptLobbyInvite("Alice", "invite-1")
 
-        assertEquals("Einladung konnte nicht angenommen werden", viewModel.lobbyError.value)
+        assertEquals("Could not accept invite", viewModel.lobbyError.value)
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/LeaderboardViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/LeaderboardViewModelTest.kt
@@ -1,0 +1,63 @@
+package at.aau.se2.skyjo.viewmodel
+
+import android.app.Application
+import at.aau.se2.skyjo.model.stats.LeaderboardEntryDto
+import at.aau.se2.skyjo.network.ApiException
+import at.aau.se2.skyjo.network.SkyjoApi
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+
+class LeaderboardViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val application = mockk<Application>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `refresh loads leaderboard entries`() {
+        val entries = listOf(LeaderboardEntryDto(1, "user-1", "Alice", 5.5, 3, 4, 2, 22))
+        val viewModel = LeaderboardViewModel(application, FakeLeaderboardApi(entries = entries))
+
+        viewModel.refresh()
+
+        assertEquals(entries, viewModel.state.value.entries)
+        assertFalse(viewModel.state.value.isLoading)
+    }
+
+    @Test
+    fun `refresh failure stores error`() {
+        val viewModel = LeaderboardViewModel(application, FakeLeaderboardApi(error = ApiException("down")))
+
+        viewModel.refresh()
+
+        assertEquals("down", viewModel.state.value.errorMessage)
+        assertFalse(viewModel.state.value.isLoading)
+    }
+
+    private class FakeLeaderboardApi(
+        private val entries: List<LeaderboardEntryDto> = emptyList(),
+        private val error: Throwable? = null,
+    ) : SkyjoApi {
+        override suspend fun leaderboard(limit: Int): List<LeaderboardEntryDto> {
+            error?.let { throw it }
+            return entries
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add login/register screen before the start screen and store session tokens via encrypted preferences.
- Replace runtime mock data with REST-backed lobby creation/joining, friends, lobby invites, and leaderboard screens.
- Authenticate STOMP connections via one-time WebSocket tickets and subscribe to lobby/game/user queues.