### PR TITLE
fix: invalid join code shows toast instead of redirecting into an empty lobby

### DIFF
--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
@@ -129,10 +129,23 @@ fun AppNavHost(
 
             composable(AppDestination.Start.route) {
                 val username = authState.user?.username.orEmpty()
+                val context = LocalContext.current
                 LaunchedEffect(username) {
                     if (username.isNotBlank()) {
                         gameViewModel.setAuthenticatedUsername(username)
                         gameViewModel.refreshHomeStats()
+                    }
+                }
+                // Navigate to the lobby only once a join-by-code actually succeeds…
+                LaunchedEffect(Unit) {
+                    gameViewModel.lobbyJoined.collect {
+                        navController.navigate(AppDestination.Lobby.route)
+                    }
+                }
+                // …and on an invalid/unjoinable code, stay here and show a toast instead.
+                LaunchedEffect(Unit) {
+                    gameViewModel.lobbyJoinError.collect { message ->
+                        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
                     }
                 }
                 StartScreen(
@@ -148,8 +161,9 @@ fun AppNavHost(
                         navController.navigate(AppDestination.Lobby.route)
                     },
                     onJoinLobby = { code ->
+                        // Navigation happens reactively via lobbyJoined / lobbyJoinError above,
+                        // so an invalid code no longer drops the user into an empty lobby.
                         gameViewModel.joinLobbyByCode(username, code)
-                        navController.navigate(AppDestination.Lobby.route)
                     },
                     onLogout = {
                         authViewModel?.logout()

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
@@ -302,8 +302,10 @@ fun AppNavHost(
                     },
                     onAcceptInvite = { inviteId ->
                         friendsViewModel?.removeLobbyInvite(inviteId)
+                        // Navigation happens reactively via the host-level lobbyJoined /
+                        // lobbyJoinError collectors once the invite is actually accepted,
+                        // so a failed/slow accept no longer drops the user into an empty lobby.
                         gameViewModel.acceptLobbyInvite(username = authState.user?.username.orEmpty(), inviteId = inviteId)
-                        navController.navigate(AppDestination.Lobby.route)
                     },
                     onDeclineInvite = { inviteId ->
                         friendsViewModel?.declineLobbyInvite(inviteId)

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
@@ -95,6 +95,20 @@ fun AppNavHost(
         }
     }
 
+    // Collected at the host level (not the Start route) so a join that completes after the
+    // user has navigated away still drives the navigation/toast instead of being dropped.
+    val appContext = LocalContext.current
+    LaunchedEffect(Unit) {
+        gameViewModel.lobbyJoined.collect {
+            navController.navigate(AppDestination.Lobby.route)
+        }
+    }
+    LaunchedEffect(Unit) {
+        gameViewModel.lobbyJoinError.collect { message ->
+            Toast.makeText(appContext, message, Toast.LENGTH_SHORT).show()
+        }
+    }
+
     // Drive per-screen background music from the active destination and the music toggle.
     val currentEntry by navController.currentBackStackEntryAsState()
     val currentRoute = currentEntry?.destination?.route
@@ -129,23 +143,10 @@ fun AppNavHost(
 
             composable(AppDestination.Start.route) {
                 val username = authState.user?.username.orEmpty()
-                val context = LocalContext.current
                 LaunchedEffect(username) {
                     if (username.isNotBlank()) {
                         gameViewModel.setAuthenticatedUsername(username)
                         gameViewModel.refreshHomeStats()
-                    }
-                }
-                // Navigate to the lobby only once a join-by-code actually succeeds…
-                LaunchedEffect(Unit) {
-                    gameViewModel.lobbyJoined.collect {
-                        navController.navigate(AppDestination.Lobby.route)
-                    }
-                }
-                // …and on an invalid/unjoinable code, stay here and show a toast instead.
-                LaunchedEffect(Unit) {
-                    gameViewModel.lobbyJoinError.collect { message ->
-                        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
                     }
                 }
                 StartScreen(
@@ -161,8 +162,9 @@ fun AppNavHost(
                         navController.navigate(AppDestination.Lobby.route)
                     },
                     onJoinLobby = { code ->
-                        // Navigation happens reactively via lobbyJoined / lobbyJoinError above,
-                        // so an invalid code no longer drops the user into an empty lobby.
+                        // Navigation happens reactively via the host-level lobbyJoined /
+                        // lobbyJoinError collectors, so an invalid code no longer drops the
+                        // user into an empty lobby.
                         gameViewModel.joinLobbyByCode(username, code)
                     },
                     onLogout = {

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/game/GameScreen.kt
@@ -160,7 +160,7 @@ fun GameScreen(
 ) {
     val haptic = LocalHaptic.current
     val audio = LocalAudio.current
-    var pendingAction by remember { mutableStateOf<String?>(null) }
+    var pendingAction by remember(isMyTurn, gameState?.roundNumber) { mutableStateOf<String?>(null) }
     var drawnFromDiscard by remember(isMyTurn, gameState?.roundNumber) { mutableStateOf(false) }
     val handleDrawFromDeck: () -> Unit = { haptic?.event(); drawnFromDiscard = false; onDrawFromDeck() }
     val handleDrawFromDiscard: () -> Unit = { haptic?.event(); drawnFromDiscard = true; onDrawFromDiscard() }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
@@ -189,8 +189,12 @@ class GameViewModel(
                         ),
                     )
                 }
+            }.onSuccess {
+                // Navigate reactively once the invite is actually accepted and connected,
+                // mirroring joinLobbyByCode, so we never drop the user into an empty lobby.
+                _lobbyJoined.tryEmit(Unit)
             }.onFailure { error ->
-                _lobbyError.value = error.message ?: "Could not accept invite"
+                _lobbyJoinError.tryEmit(error.message ?: "Could not accept invite")
             }
         }
     }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
@@ -51,6 +51,14 @@ class GameViewModel(
     private val _lobbyError = MutableStateFlow<String?>(null)
     val lobbyError: StateFlow<String?> = _lobbyError.asStateFlow()
 
+    /** One-shot event: a join-by-code succeeded; the UI should navigate to the lobby. */
+    private val _lobbyJoined = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val lobbyJoined: SharedFlow<Unit> = _lobbyJoined.asSharedFlow()
+
+    /** One-shot event: a join-by-code failed; carries a user-facing message for a toast. */
+    private val _lobbyJoinError = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val lobbyJoinError: SharedFlow<String> = _lobbyJoinError.asSharedFlow()
+
     private var leaveJob: kotlinx.coroutines.Job? = null
 
     val isHost: StateFlow<Boolean> = combine(lobbyState, myPlayerName) { lobby, name ->
@@ -153,8 +161,12 @@ class GameViewModel(
                         maxPlayers = lobby.maxPlayers,
                     ),
                 )
+            }.onSuccess {
+                _lobbyJoined.tryEmit(Unit)
             }.onFailure { error ->
-                _lobbyError.value = error.message ?: "Could not join lobby"
+                // Surfaced as a toast on the Start screen; the backend sends "lobby not found"
+                // for an invalid code, "cannot join: lobby is not waiting", etc.
+                _lobbyJoinError.tryEmit(error.message ?: "Could not join lobby")
             }
         }
     }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
@@ -15,6 +15,7 @@ import at.aau.se2.skyjo.network.SkyjoApi
 import at.aau.se2.skyjo.network.SkyjoApiClient
 import at.aau.se2.skyjo.session.EncryptedSessionStore
 import at.aau.se2.skyjo.session.SessionStore
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
@@ -51,13 +52,18 @@ class GameViewModel(
     private val _lobbyError = MutableStateFlow<String?>(null)
     val lobbyError: StateFlow<String?> = _lobbyError.asStateFlow()
 
-    /** One-shot event: a join-by-code succeeded; the UI should navigate to the lobby. */
-    private val _lobbyJoined = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    val lobbyJoined: SharedFlow<Unit> = _lobbyJoined.asSharedFlow()
+    // One-shot navigation/toast events use a buffered Channel rather than a non-replaying
+    // SharedFlow: if the Activity (and the host-level collector) is recreated while a
+    // join/accept request is still in flight, the buffered element is delivered to the next
+    // collector instead of being dropped.
 
-    /** One-shot event: a join-by-code failed; carries a user-facing message for a toast. */
-    private val _lobbyJoinError = MutableSharedFlow<String>(extraBufferCapacity = 1)
-    val lobbyJoinError: SharedFlow<String> = _lobbyJoinError.asSharedFlow()
+    /** One-shot event: a join-by-code/invite succeeded; the UI should navigate to the lobby. */
+    private val _lobbyJoined = Channel<Unit>(Channel.BUFFERED)
+    val lobbyJoined: Flow<Unit> = _lobbyJoined.receiveAsFlow()
+
+    /** One-shot event: a join/accept failed; carries a user-facing message for a toast. */
+    private val _lobbyJoinError = Channel<String>(Channel.BUFFERED)
+    val lobbyJoinError: Flow<String> = _lobbyJoinError.receiveAsFlow()
 
     private var leaveJob: kotlinx.coroutines.Job? = null
 
@@ -162,11 +168,11 @@ class GameViewModel(
                     ),
                 )
             }.onSuccess {
-                _lobbyJoined.tryEmit(Unit)
+                _lobbyJoined.trySend(Unit)
             }.onFailure { error ->
                 // Surfaced as a toast on the Start screen; the backend sends "lobby not found"
                 // for an invalid code, "cannot join: lobby is not waiting", etc.
-                _lobbyJoinError.tryEmit(error.message ?: "Could not join lobby")
+                _lobbyJoinError.trySend(error.message ?: "Could not join lobby")
             }
         }
     }
@@ -176,25 +182,26 @@ class GameViewModel(
         viewModelScope.launch {
             runCatching {
                 val invite = apiClient.acceptLobbyInvite(inviteId)
+                // Treat a missing current lobby as a failure: emitting lobbyJoined without an
+                // applied lobby state would navigate the user into an empty lobby screen.
                 val lobby = apiClient.currentLobby()
+                    ?: error("Could not load lobby after accepting invite")
                 connectToLobby(invite.joinCode)
-                lobby?.let {
-                    gameClient.applyLobbyState(
-                        LobbyUpdateMessage(
-                            lobbyId = it.lobbyId,
-                            joinCode = it.joinCode,
-                            players = it.players,
-                            status = it.status,
-                            maxPlayers = it.maxPlayers,
-                        ),
-                    )
-                }
+                gameClient.applyLobbyState(
+                    LobbyUpdateMessage(
+                        lobbyId = lobby.lobbyId,
+                        joinCode = lobby.joinCode,
+                        players = lobby.players,
+                        status = lobby.status,
+                        maxPlayers = lobby.maxPlayers,
+                    ),
+                )
             }.onSuccess {
-                // Navigate reactively once the invite is actually accepted and connected,
-                // mirroring joinLobbyByCode, so we never drop the user into an empty lobby.
-                _lobbyJoined.tryEmit(Unit)
+                // Navigate reactively only once the invite is accepted, connected and the lobby
+                // state is applied, mirroring joinLobbyByCode, so we never land in an empty lobby.
+                _lobbyJoined.trySend(Unit)
             }.onFailure { error ->
-                _lobbyJoinError.tryEmit(error.message ?: "Could not accept invite")
+                _lobbyJoinError.trySend(error.message ?: "Could not accept invite")
             }
         }
     }

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHostTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHostTest.kt
@@ -2,12 +2,14 @@ package at.aau.se2.skyjo.ui.navigation
 
 import android.app.Application
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -150,6 +152,30 @@ class AppNavHostTest {
             }
         }
         composeTestRule.onNodeWithText("SKYJO", substring = true).assertExists()
+    }
+
+    @Test
+    fun appNavHost_invalid_join_code_does_not_navigate_into_lobby() {
+        coEvery { mockApi.joinLobby(any()) } throws IllegalStateException("lobby not found")
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        lateinit var navController: NavHostController
+        composeTestRule.setContent {
+            SkyjoTheme {
+                navController = rememberNavController()
+                AppNavHost(navController = navController, gameViewModel = viewModel)
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNode(hasSetTextAction()).performTextInput("BAD123")
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("JOIN WITH CODE").performClick()
+        composeTestRule.waitForIdle()
+
+        // The failed join must NOT drop the user into an (empty) lobby screen.
+        // The "lobby not found" toast itself is covered by GameViewModelTest (lobbyJoinError event).
+        assertEquals(AppDestination.Start.route, navController.currentDestination?.route)
+        verify(exactly = 0) { mockGameClient.applyLobbyState(any()) }
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
@@ -360,15 +360,24 @@ class GameViewModelTest {
     }
 
     @Test
-    fun `acceptLobbyInvite skips lobby state when current lobby is missing`() {
+    fun `acceptLobbyInvite emits error and does not connect or join when current lobby is missing`() {
         coEvery { mockApi.acceptLobbyInvite("invite-1") } returns lobbyInvite()
         coEvery { mockApi.currentLobby() } returns null
         val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        var joinedCount = 0
+        val errors = mutableListOf<String>()
+        val joinedJob = CoroutineScope(testDispatcher).launch { viewModel.lobbyJoined.collect { joinedCount++ } }
+        val errorJob = CoroutineScope(testDispatcher).launch { viewModel.lobbyJoinError.collect { errors.add(it) } }
 
         viewModel.acceptLobbyInvite("Alice", "invite-1")
 
-        coVerify(exactly = 1) { mockGameClient.connect("ticket", "ABC123") }
+        // A missing lobby must not navigate the user into an empty lobby screen.
+        assertEquals(listOf("Could not load lobby after accepting invite"), errors)
+        assertEquals(0, joinedCount)
+        coVerify(exactly = 0) { mockGameClient.connect(any(), any()) }
         verify(exactly = 0) { mockGameClient.applyLobbyState(any()) }
+        joinedJob.cancel()
+        errorJob.cancel()
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
@@ -31,7 +31,9 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -295,13 +297,51 @@ class GameViewModelTest {
     }
 
     @Test
-    fun `joinLobbyByCode stores fallback error when exception has no message`() {
+    fun `joinLobbyByCode emits joined event and no error on success`() {
+        coEvery { mockApi.joinLobby("abc123") } returns lobbySummary()
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        var joinedCount = 0
+        val errors = mutableListOf<String>()
+        val joinedJob = CoroutineScope(testDispatcher).launch { viewModel.lobbyJoined.collect { joinedCount++ } }
+        val errorJob = CoroutineScope(testDispatcher).launch { viewModel.lobbyJoinError.collect { errors.add(it) } }
+
+        viewModel.joinLobbyByCode("Alice", "abc123")
+
+        assertEquals(1, joinedCount)
+        assertTrue(errors.isEmpty())
+        joinedJob.cancel()
+        errorJob.cancel()
+    }
+
+    @Test
+    fun `joinLobbyByCode emits the server message and does not navigate on invalid code`() {
+        coEvery { mockApi.joinLobby("BAD123") } throws IllegalStateException("lobby not found")
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        var joinedCount = 0
+        val errors = mutableListOf<String>()
+        val joinedJob = CoroutineScope(testDispatcher).launch { viewModel.lobbyJoined.collect { joinedCount++ } }
+        val errorJob = CoroutineScope(testDispatcher).launch { viewModel.lobbyJoinError.collect { errors.add(it) } }
+
+        viewModel.joinLobbyByCode("Alice", "BAD123")
+
+        assertEquals(listOf("lobby not found"), errors)
+        assertEquals(0, joinedCount)
+        verify(exactly = 0) { mockGameClient.applyLobbyState(any()) }
+        joinedJob.cancel()
+        errorJob.cancel()
+    }
+
+    @Test
+    fun `joinLobbyByCode emits fallback message when exception has no message`() {
         coEvery { mockApi.joinLobby("bad") } throws object : RuntimeException() {}
         val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        val errors = mutableListOf<String>()
+        val errorJob = CoroutineScope(testDispatcher).launch { viewModel.lobbyJoinError.collect { errors.add(it) } }
 
         viewModel.joinLobbyByCode("Alice", "bad")
 
-        assertEquals("Could not join lobby", viewModel.lobbyError.value)
+        assertEquals(listOf("Could not join lobby"), errors)
+        errorJob.cancel()
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
@@ -372,13 +372,38 @@ class GameViewModelTest {
     }
 
     @Test
-    fun `acceptLobbyInvite stores fallback error when request fails without message`() {
-        coEvery { mockApi.acceptLobbyInvite("invite-1") } throws object : RuntimeException() {}
+    fun `acceptLobbyInvite emits joined event and no error on success`() {
+        coEvery { mockApi.acceptLobbyInvite("invite-1") } returns lobbyInvite()
+        coEvery { mockApi.currentLobby() } returns lobbySummary()
         val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        var joinedCount = 0
+        val errors = mutableListOf<String>()
+        val joinedJob = CoroutineScope(testDispatcher).launch { viewModel.lobbyJoined.collect { joinedCount++ } }
+        val errorJob = CoroutineScope(testDispatcher).launch { viewModel.lobbyJoinError.collect { errors.add(it) } }
 
         viewModel.acceptLobbyInvite("Alice", "invite-1")
 
-        assertEquals("Could not accept invite", viewModel.lobbyError.value)
+        assertEquals(1, joinedCount)
+        assertTrue(errors.isEmpty())
+        joinedJob.cancel()
+        errorJob.cancel()
+    }
+
+    @Test
+    fun `acceptLobbyInvite emits fallback error event and does not join when request fails without message`() {
+        coEvery { mockApi.acceptLobbyInvite("invite-1") } throws object : RuntimeException() {}
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        var joinedCount = 0
+        val errors = mutableListOf<String>()
+        val joinedJob = CoroutineScope(testDispatcher).launch { viewModel.lobbyJoined.collect { joinedCount++ } }
+        val errorJob = CoroutineScope(testDispatcher).launch { viewModel.lobbyJoinError.collect { errors.add(it) } }
+
+        viewModel.acceptLobbyInvite("Alice", "invite-1")
+
+        assertEquals(listOf("Could not accept invite"), errors)
+        assertEquals(0, joinedCount)
+        joinedJob.cancel()
+        errorJob.cancel()
     }
 
     @Test


### PR DESCRIPTION
## Problem

Entering a random/invalid lobby join code dropped the user **into the Lobby screen**, which then showed a backend error like *"lobby not found"* / *"lobby is not waiting"*.

**Root cause:** `onJoinLobby` navigated to the Lobby route **immediately and unconditionally**, while `joinLobbyByCode` runs asynchronously. So the navigation happened before the join result was known; the failed join then surfaced as an error inside the lobby.

## Fix (frontend only)

`GameViewModel.joinLobbyByCode` now emits one-shot events:
- **`lobbyJoined`** on success → the Start screen navigates to the Lobby.
- **`lobbyJoinError`** on failure → the Start screen shows a **toast** with the server message and **stays on Start**.

The Start screen's `onJoinLobby` no longer navigates eagerly. The backend already returns `404 "lobby not found"` for invalid codes (and a clear message for *not waiting* / *full*), so the toast reads "lobby not found" for an invalid code — **no backend change needed**.

## Tests

- `GameViewModelTest`:
  - success → emits `lobbyJoined`, no error
  - invalid code → emits the server message (`"lobby not found"`), no `lobbyJoined`, never calls `applyLobbyState`
  - no-message exception → fallback `"Could not join lobby"`
- `AppNavHostTest`: invalid code keeps the user on the Start screen and never applies a lobby state.
- Full `:app:testDebugUnitTest` suite green.