### PR TITLE
fix: leave lobby on back navigation and self-heal stale membership

### DIFF
--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHost.kt
@@ -222,6 +222,19 @@ fun AppNavHost(
                     mutableStateOf<CheatPeekResultMessage?>(null)
                 }
 
+                // Backing out of a running game (system gesture or the in-game back button)
+                // must release the server-side lobby membership, otherwise the backend keeps
+                // reporting "user is already in a lobby" on the Start screen.
+                val leaveGame: () -> Unit = {
+                    gameViewModel.leaveLobby()
+                    navController.navigate(AppDestination.Start.route) {
+                        popUpTo(AppDestination.Start.route) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                }
+
+                BackHandler(onBack = leaveGame)
+
                 LaunchedEffect(Unit) {
                     gameViewModel.actionCardResults.collect { result ->
                         privateActionCardResult = result
@@ -272,7 +285,7 @@ fun AppNavHost(
                     onReportCheat = { gameViewModel.cheatReportCurrentPlayer() },
                     onDismissCheatPeekResult = { privateCheatPeekResult = null },
                     onReadyForNextRoundClick = { gameViewModel.startNextRound() },
-                    onBack = { navController.popBackStack() },
+                    onBack = leaveGame,
                     onNavigateToGameOver = {
                         navController.navigate(AppDestination.GameOver.route) {
                             // Das Spiel wird aus dem Verlauf gelöscht,

--- a/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModel.kt
@@ -8,6 +8,7 @@ import at.aau.se2.skyjo.model.BoardLineTargetType
 import at.aau.se2.skyjo.model.GameAction
 import at.aau.se2.skyjo.model.LobbyUpdateMessage
 import at.aau.se2.skyjo.model.PlayActionCardCommand
+import at.aau.se2.skyjo.model.lobby.LobbySummaryResponse
 import at.aau.se2.skyjo.model.stats.PlayerStatsDto
 import at.aau.se2.skyjo.network.GameRealtimeClient
 import at.aau.se2.skyjo.network.GameStompClient
@@ -163,7 +164,7 @@ class GameViewModel(
                 leaveJob?.join()
                 coroutineContext.ensureActive()
                 _lobbyError.value = null
-                val lobby = apiClient.createLobby()
+                val lobby = createLobbyClearingStaleMembership()
                 coroutineContext.ensureActive()
                 connectToLobby(lobby.joinCode)
                 coroutineContext.ensureActive()
@@ -366,5 +367,22 @@ class GameViewModel(
     private suspend fun connectToLobby(joinCode: String) {
         val ticket = apiClient.createWebSocketTicket().ticket
         gameClient.connect(ticket = ticket, lobbyJoinCode = joinCode)
+    }
+
+    // A session that ended abruptly (app killed/crashed) can leave the user registered in a
+    // lobby server-side until the socket times out. In that window createLobby fails with
+    // "user is already in a lobby". Release that stale membership once and retry so the user
+    // isn't stuck, even when there is no local lobby state to leave from.
+    private suspend fun createLobbyClearingStaleMembership(): LobbySummaryResponse {
+        return try {
+            apiClient.createLobby()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            if (error.message?.contains("already in a lobby", ignoreCase = true) != true) throw error
+            val staleLobbyId = apiClient.currentLobby()?.lobbyId ?: throw error
+            apiClient.leaveLobby(staleLobbyId)
+            apiClient.createLobby()
+        }
     }
 }

--- a/app/src/test/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHostTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/ui/navigation/AppNavHostTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -779,6 +780,36 @@ class AppNavHostTest {
         // Optional: Überprüfe, ob wir uns wieder auf der Startseite befinden,
         // indem wir nach einem Element suchen, das spezifisch für den StartScreen ist.
         composeTestRule.onNodeWithText("Create Lobby", ignoreCase = true, substring = true).assertExists()
+    }
+
+    @Test
+    fun appNavHost_game_back_button_clears_lobby_and_navigates_to_start() {
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+        fakeGameState.value = makeGameState()
+        viewModel.connect("Alice")
+        lateinit var navController: NavHostController
+
+        composeTestRule.setContent {
+            SkyjoTheme {
+                navController = rememberNavController()
+                AppNavHost(navController = navController, gameViewModel = viewModel)
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        // Rejoin drives navigation into the running game.
+        fakeHasRejoinedGame.value = true
+        composeTestRule.waitForIdle()
+        assertEquals(AppDestination.Game.route, navController.currentDestination?.route)
+
+        // The in-game back button (ArrowBack, contentDescription "Back") must leave the game.
+        composeTestRule.onNodeWithContentDescription("Back").performClick()
+        composeTestRule.waitForIdle()
+
+        // Leaving releases the server-side lobby membership...
+        verify(exactly = 1) { mockGameClient.leaveLobby() }
+        // ...and returns to the Start screen.
+        assertEquals(AppDestination.Start.route, navController.currentDestination?.route)
     }
 
     // Helper function

--- a/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/viewmodel/GameViewModelTest.kt
@@ -287,6 +287,24 @@ class GameViewModelTest {
     }
 
     @Test
+    fun `createLobby clears stale membership and retries when already in a lobby`() {
+        coEvery { mockApi.createLobby() } throws
+            IllegalStateException("user is already in a lobby") andThen
+            lobbySummary(lobbyId = "lobby-2", joinCode = "NEW123")
+        coEvery { mockApi.currentLobby() } returns lobbySummary(lobbyId = "stale-1")
+        coEvery { mockApi.leaveLobby("stale-1") } returns lobbySummary(lobbyId = "stale-1")
+        val viewModel = GameViewModel(mockApplication, mockApi, mockGameClient)
+
+        viewModel.createLobby("Alice")
+
+        assertEquals(null, viewModel.lobbyError.value)
+        coVerify(exactly = 1) { mockApi.currentLobby() }
+        coVerify(exactly = 1) { mockApi.leaveLobby("stale-1") }
+        coVerify(exactly = 2) { mockApi.createLobby() }
+        coVerify(exactly = 1) { mockGameClient.connect("ticket", "NEW123") }
+    }
+
+    @Test
     fun `createLobbyAndInvite creates lobby applies state and sends invite`() {
         coEvery { mockApi.createLobby() } returns lobbySummary(lobbyId = "lobby-9", joinCode = "XYZ789")
         coEvery { mockApi.sendLobbyInvite("lobby-9", "friend-1") } returns lobbyInvite()


### PR DESCRIPTION
## Problem

Pressing back (gesture or button) from a running game never left the lobby server-side. The **Game route had no `BackHandler`**, and its `onBack` only called `navController.popBackStack()` without `leaveLobby()`. The app navigated away while the backend still had the player registered, so the next lobby creation failed with `"user is already in a lobby"` — even from the Start screen. (The Lobby and GameOver routes already handled this.)

## Fix

- **Game route**: add a `BackHandler` + wire `onBack` to a `leaveGame` handler that calls `gameViewModel.leaveLobby()` and returns to Start, mirroring the GameOver route.
- **Self-healing `createLobby`**: if the backend still reports `"already in a lobby"` (e.g. after an abrupt app kill, before the WebSocket timed out server-side), the client now releases the stale membership via `currentLobby()` → `leaveLobby()` and retries once — even when there's no local lobby state to leave from.

## Notes

The backend already cleans up on `SessionDisconnectEvent`, so graceful leaves and dropped sockets were covered; this closes the remaining gap where the client navigated away without disconnecting, plus the abrupt-kill timing window.

## Tests

- `AppNavHostTest`: in-game back button leaves the lobby and navigates to Start.
- `GameViewModelTest`: `createLobby` clears stale membership and retries when the backend reports "already in a lobby".

All `AppNavHostTest` and `GameViewModelTest` suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)