### PR TITLE
refactor(client): drop unused global lobby/game STOMP topics

### DIFF
--- a/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/network/GameStompClient.kt
@@ -71,10 +71,11 @@ class GameStompClient(context: Context) : GameRealtimeClient {
             replaceSession(ticket)
 
             // Subscribe before returning so lobby actions cannot miss first updates.
+            // Authenticated only: the lobby topic is per join-code and game updates
+            // arrive via /user/queue/gamestate -> /topic/games/{id} (subscribeGameTopic).
+            // The former global /topic/lobby and /topic/game topics are no longer used.
             val s = session!!
-            val lobbyFlow       = s.subscribeText(lobbyJoinCode?.let { "/topic/lobbies/$it" } ?: "/topic/lobby")
             val lobbyDirectFlow = s.subscribeText("/user/queue/lobby")
-            val gameFlow        = s.subscribeText("/topic/game")
             val errorsFlow      = s.subscribeText("/user/queue/errors")
             val rejoinFlow      = s.subscribeText("/user/queue/gamestate")
             val actionCardResultsFlow = s.subscribeText("/user/queue/action-card-results")
@@ -82,10 +83,9 @@ class GameStompClient(context: Context) : GameRealtimeClient {
             val cheatReportResultsFlow = s.subscribeText("/user/queue/cheat-report-results")
             val invitesFlow = s.subscribeText("/user/queue/invites")
 
-            subscriptionJobs += listOf(
-                scope.launch { collectLobby(lobbyFlow) },
+            subscriptionJobs += listOfNotNull(
+                lobbyJoinCode?.let { code -> scope.launch { collectLobby(s.subscribeText("/topic/lobbies/$code")) } },
                 scope.launch { collectLobbyDirect(lobbyDirectFlow) },
-                scope.launch { collectGame(gameFlow) },
                 scope.launch { collectErrors(errorsFlow) },
                 scope.launch { collectRejoinState(rejoinFlow) },
                 scope.launch { collectActionCardResults(actionCardResultsFlow) },

--- a/app/src/test/kotlin/at/aau/se2/skyjo/network/GameStompClientConnectTopicsTest.kt
+++ b/app/src/test/kotlin/at/aau/se2/skyjo/network/GameStompClientConnectTopicsTest.kt
@@ -1,0 +1,87 @@
+package at.aau.se2.skyjo.network
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import io.mockk.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
+import org.hildan.krossbow.stomp.StompClient
+import org.hildan.krossbow.stomp.StompSession
+import org.hildan.krossbow.stomp.sendText
+import org.hildan.krossbow.stomp.subscribeText
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Verifies that connect() only subscribes the authenticated topic set and no
+ * longer the (removed) global /topic/lobby and /topic/game topics.
+ */
+class GameStompClientConnectTopicsTest {
+
+    private lateinit var mockSession: StompSession
+    private lateinit var topicFlow: MutableSharedFlow<String>
+    private lateinit var mockContext: Context
+    private lateinit var mockPrefs: SharedPreferences
+    private lateinit var mockEditor: SharedPreferences.Editor
+
+    @Before
+    fun setup() {
+        mockkStatic(Log::class)
+        mockkStatic("org.hildan.krossbow.stomp.StompClientKt")
+        mockkStatic("org.hildan.krossbow.stomp.StompSessionKt")
+        mockkConstructor(StompClient::class)
+
+        mockSession = mockk(relaxed = true)
+        topicFlow = MutableSharedFlow()
+
+        mockContext = mockk(relaxed = true)
+        mockPrefs = mockk(relaxed = true)
+        mockEditor = mockk(relaxed = true)
+
+        every { mockContext.getSharedPreferences(any(), any()) } returns mockPrefs
+        every { mockPrefs.getString(any(), any()) } returns null
+        every { mockPrefs.edit() } returns mockEditor
+        every { mockEditor.putString(any(), any()) } returns mockEditor
+        every { mockEditor.remove(any()) } returns mockEditor
+        every { mockEditor.apply() } just runs
+
+        every { Log.d(any(), any()) } returns 0
+        every { Log.e(any(), any()) } returns 0
+
+        coEvery {
+            anyConstructed<StompClient>().connect(url = any(), any(), any(), any(), any(), any())
+        } returns mockSession
+
+        coEvery { any<StompSession>().subscribeText(any()) } returns topicFlow
+        coEvery { any<StompSession>().sendText(any(), any()) } returns null
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `connect subscribes join-code lobby topic and not the global lobby or game topics`() = runBlocking {
+        val client = GameStompClient(mockContext)
+        client.connect(ticket = "ticket", lobbyJoinCode = "ABC123")
+        delay(300)
+
+        coVerify(atLeast = 1) { any<StompSession>().subscribeText("/topic/lobbies/ABC123") }
+        coVerify(exactly = 0) { any<StompSession>().subscribeText("/topic/lobby") }
+        coVerify(exactly = 0) { any<StompSession>().subscribeText("/topic/game") }
+    }
+
+    @Test
+    fun `connect without a join code subscribes neither the global lobby nor game topic`() = runBlocking {
+        val client = GameStompClient(mockContext)
+        client.connect()
+        delay(300)
+
+        coVerify(exactly = 0) { any<StompSession>().subscribeText("/topic/lobby") }
+        coVerify(exactly = 0) { any<StompSession>().subscribeText("/topic/game") }
+    }
+}


### PR DESCRIPTION
## What & why

The client subscribed to two **global** STOMP topics — `/topic/lobby` and
`/topic/game` — left over from the removed anonymous single-lobby prototype. The
backend no longer broadcasts to either (authenticated updates go to
`/topic/lobbies/{joinCode}` and `/topic/games/{gameId}`), so these subscriptions
only ever received nothing.

This trims `GameStompClient.connect()` to the authenticated topic set.

## Changes

- `GameStompClient.connect(ticket, lobbyJoinCode)`:
  - Subscribe the lobby topic **only when a join code is present**
    (`/topic/lobbies/{code}`); drop the `?: "/topic/lobby"` global fallback.
  - Remove the global `/topic/game` subscription entirely.
- Game updates are unaffected: they arrive on `/user/queue/gamestate`
  (`collectRejoinState`), which calls `subscribeGameTopic(gameId)` →
  `/topic/games/{gameId}`. `isRejoinable()` is true for an active game, so a
  freshly started game subscribes its per-game topic immediately.

## Testing

Frontend unit suite green. Added two tests mirroring the existing
`connectForInvites` topic assertion: `connect(ticket, joinCode)` subscribes
`/topic/lobbies/{code}` and never `/topic/lobby` / `/topic/game`; `connect()`
without a join code subscribes neither.

## Context

Client-side completion of the authenticated-only migration (backend PR #45).
