### PR TITLE
feat(ui): fresh motion & polish pass (spring buttons, depth, confetti)

### DIFF
--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/components/AnimatedCounter.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/components/AnimatedCounter.kt
@@ -1,0 +1,40 @@
+package at.aau.se2.skyjo.ui.components
+
+import androidx.compose.animation.core.animateIntAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import at.aau.se2.skyjo.ui.theme.Motion
+import at.aau.se2.skyjo.ui.theme.rememberReducedMotion
+
+/**
+ * A number that rolls up/down to [value] instead of snapping — used for score
+ * reveals. Settles on the exact [value] (and shows it immediately under reduced
+ * motion), so assertions on the final number stay valid.
+ */
+@Composable
+fun AnimatedCounter(
+    value: Int,
+    modifier: Modifier = Modifier,
+    style: TextStyle = LocalTextStyle.current,
+    color: Color = Color.Unspecified,
+    suffix: String = "",
+) {
+    val reduced = rememberReducedMotion()
+    val animated by animateIntAsState(
+        targetValue = value,
+        animationSpec = tween(durationMillis = Motion.Slow),
+        label = "animatedCounter",
+    )
+    Text(
+        text = "${if (reduced) value else animated}$suffix",
+        modifier = modifier,
+        style = style,
+        color = color,
+    )
+}

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/components/BouncyModifiers.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/components/BouncyModifiers.kt
@@ -1,0 +1,54 @@
+package at.aau.se2.skyjo.ui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.graphicsLayer
+import at.aau.se2.skyjo.ui.theme.Motion
+import at.aau.se2.skyjo.ui.theme.rememberReducedMotion
+import kotlinx.coroutines.delay
+
+/**
+ * Springy scale-down while pressed. Pass the same [interactionSource] the clickable
+ * uses. Purely a visual transform, so it never changes the composable tree.
+ */
+@Composable
+fun Modifier.bouncyPress(
+    interactionSource: MutableInteractionSource,
+    pressedScale: Float = 0.94f,
+): Modifier {
+    val pressed by interactionSource.collectIsPressedAsState()
+    val reduced = rememberReducedMotion()
+    val scale by animateFloatAsState(
+        targetValue = if (pressed && !reduced) pressedScale else 1f,
+        animationSpec = Motion.bouncyFloat,
+        label = "bouncyPress",
+    )
+    return this.scale(scale)
+}
+
+/**
+ * Fade + rise entrance on first composition, with an optional stagger [delayMillis].
+ * Ends fully visible (alpha 1, no offset), and no-ops under reduced motion, so it is
+ * safe for content that tests assert on.
+ */
+@Composable
+fun Modifier.entrance(delayMillis: Int = 0): Modifier {
+    if (rememberReducedMotion()) return this
+    val progress = remember { Animatable(0f) }
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        if (delayMillis > 0) delay(delayMillis.toLong())
+        progress.animateTo(1f, animationSpec = tween(Motion.Normal))
+    }
+    return this.graphicsLayer {
+        alpha = progress.value
+        translationY = (1f - progress.value) * 36f
+    }
+}

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/components/CommonComponents.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/components/CommonComponents.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -20,6 +21,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -47,17 +49,22 @@ fun PrimaryButton(
     enabled: Boolean = true,
 ) {
     val haptic = LocalHaptic.current
+    val interactionSource = remember { MutableInteractionSource() }
     Button(
         onClick = {
             haptic?.tick()
             onClick()
         },
         enabled = enabled,
-        modifier = modifier.fillMaxWidth(),
+        interactionSource = interactionSource,
+        modifier = modifier
+            .fillMaxWidth()
+            .bouncyPress(interactionSource),
         shape = MaterialTheme.shapes.extraLarge,
         colors = ButtonDefaults.buttonColors(
             containerColor = PrimaryGreen,
         ),
+        elevation = ButtonDefaults.buttonElevation(defaultElevation = 3.dp, pressedElevation = 1.dp),
     ) {
         Text(
             text = text,
@@ -75,12 +82,16 @@ fun SecondaryButton(
     modifier: Modifier = Modifier,
 ) {
     val haptic = LocalHaptic.current
+    val interactionSource = remember { MutableInteractionSource() }
     OutlinedButton(
         onClick = {
             haptic?.tick()
             onClick()
         },
-        modifier = modifier.fillMaxWidth(),
+        interactionSource = interactionSource,
+        modifier = modifier
+            .fillMaxWidth()
+            .bouncyPress(interactionSource),
         shape = MaterialTheme.shapes.extraLarge,
     ) {
         Text(
@@ -101,7 +112,7 @@ fun SkyjoCard(
     Card(
         modifier = modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 5.dp, pressedElevation = 8.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
     ) {
         Column(modifier = Modifier.padding(20.dp)) {

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/components/ConfettiOverlay.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/components/ConfettiOverlay.kt
@@ -1,0 +1,80 @@
+package at.aau.se2.skyjo.ui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.rotate
+import at.aau.se2.skyjo.ui.theme.BlueAccent
+import at.aau.se2.skyjo.ui.theme.DangerRed
+import at.aau.se2.skyjo.ui.theme.GoldYellow
+import at.aau.se2.skyjo.ui.theme.MintGreen
+import at.aau.se2.skyjo.ui.theme.PrimaryGreenMid
+import at.aau.se2.skyjo.ui.theme.rememberReducedMotion
+import kotlin.random.Random
+
+private data class ConfettiPiece(
+    val xFraction: Float,
+    val color: Color,
+    val size: Float,
+    val rotation: Float,
+    val drift: Float,
+    val delay: Float,
+)
+
+/**
+ * A one-shot, purely decorative in-screen confetti burst that rains down over the
+ * area it fills. Draw it on top of the content you want to celebrate. No-ops when
+ * [show] is false or the OS has animations disabled.
+ */
+@Composable
+fun ConfettiOverlay(
+    show: Boolean,
+    modifier: Modifier = Modifier,
+    pieceCount: Int = 90,
+) {
+    if (!show || rememberReducedMotion()) return
+
+    val colors = listOf(PrimaryGreenMid, MintGreen, BlueAccent, GoldYellow, DangerRed)
+    val pieces = remember(show) {
+        List(pieceCount) {
+            ConfettiPiece(
+                xFraction = Random.nextFloat(),
+                color = colors[Random.nextInt(colors.size)],
+                size = 8f + Random.nextFloat() * 10f,
+                rotation = Random.nextFloat() * 360f,
+                drift = (Random.nextFloat() - 0.5f) * 0.3f,
+                delay = Random.nextFloat() * 0.25f,
+            )
+        }
+    }
+    val progress = remember(show) { Animatable(0f) }
+    LaunchedEffect(show) {
+        progress.snapTo(0f)
+        progress.animateTo(1f, animationSpec = tween(durationMillis = 1800))
+    }
+
+    Canvas(modifier = modifier.fillMaxSize()) {
+        val t = progress.value
+        pieces.forEach { p ->
+            val local = ((t - p.delay) / (1f - p.delay)).coerceIn(0f, 1f)
+            val x = (p.xFraction + p.drift * local) * size.width
+            val y = (-0.1f + local * 1.2f) * size.height
+            val alpha = (1f - local).coerceIn(0f, 1f)
+            rotate(degrees = p.rotation + local * 360f, pivot = Offset(x, y)) {
+                drawRect(
+                    color = p.color.copy(alpha = alpha),
+                    topLeft = Offset(x - p.size / 2f, y - p.size / 2f),
+                    size = Size(p.size, p.size * 0.6f),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/gameOver/GameOverScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/gameOver/GameOverScreen.kt
@@ -77,10 +77,10 @@ fun GameOverScreen(
             }
         }
     ) { paddingValues ->
+        Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues) // Wichtig: Scaffold-Padding anwenden, damit die TopBar nichts verdeckt
                 .padding(24.dp), // Dein bestehendes Screen-Padding
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -136,6 +136,9 @@ fun GameOverScreen(
                 text = "BACK TO START",
                 onClick = onBackToStart
             )
+        }
+            // Celebrate the finish with an in-screen confetti burst.
+            ConfettiOverlay(show = true, modifier = Modifier.fillMaxSize())
         }
     }
 }

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/start/StartScreen.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/screens/start/StartScreen.kt
@@ -41,6 +41,7 @@ import at.aau.se2.skyjo.model.stats.PlayerStatsDto
 import at.aau.se2.skyjo.ui.components.AvatarBadge
 import at.aau.se2.skyjo.ui.components.PrimaryButton
 import at.aau.se2.skyjo.ui.components.SkyjoCard
+import at.aau.se2.skyjo.ui.components.entrance
 import at.aau.se2.skyjo.ui.components.SkyjoDrawerScaffold
 import at.aau.se2.skyjo.ui.components.screenHorizontalPadding
 import at.aau.se2.skyjo.ui.navigation.AppDestination
@@ -82,7 +83,7 @@ fun StartScreen(
                     .padding(horizontal = screenHorizontalPadding(), vertical = 24.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                SkyjoCard {
+                SkyjoCard(modifier = Modifier.entrance()) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically,
@@ -125,7 +126,7 @@ fun StartScreen(
                     }
                 }
 
-                SkyjoCard {
+                SkyjoCard(modifier = Modifier.entrance(delayMillis = 90)) {
                     Text(
                         text = "Lobby",
                         style = MaterialTheme.typography.titleLarge,

--- a/app/src/main/kotlin/at/aau/se2/skyjo/ui/theme/Motion.kt
+++ b/app/src/main/kotlin/at/aau/se2/skyjo/ui/theme/Motion.kt
@@ -1,0 +1,50 @@
+package at.aau.se2.skyjo.ui.theme
+
+import android.provider.Settings
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.Dp
+
+/**
+ * Shared motion tokens so animations feel consistent and intentional across every
+ * screen. Durations are in milliseconds. The spring specs give the app its playful,
+ * slightly bouncy character without being distracting.
+ */
+object Motion {
+    const val Fast = 140
+    const val Normal = 280
+    const val Slow = 520
+
+    /** Playful overshoot — for press feedback, pops and reveals. */
+    val bouncyFloat: AnimationSpec<Float>
+        get() = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMediumLow)
+
+    /** Smooth, no overshoot — for entrances and value changes. */
+    val gentleFloat: AnimationSpec<Float>
+        get() = spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessLow)
+
+    val bouncyDp: AnimationSpec<Dp>
+        get() = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMediumLow)
+}
+
+/**
+ * True when the OS has animations turned off (accessibility or battery saver).
+ * Decorative effects should collapse to their final state instead of animating.
+ */
+@Composable
+fun rememberReducedMotion(): Boolean {
+    val context = LocalContext.current
+    return remember(context) {
+        runCatching {
+            Settings.Global.getFloat(
+                context.contentResolver,
+                Settings.Global.ANIMATOR_DURATION_SCALE,
+                1f,
+            )
+        }.getOrDefault(1f) == 0f
+    }
+}


### PR DESCRIPTION
## What & why

A frontend-only polish + motion pass to make the app feel fresher and more
playful. **No rule changes, no backend, no protocol changes** — same game, more
"juice". Effects stay in-screen (consistent with the app's existing preference)
and respect the system "remove animations" accessibility setting.

## A shared motion kit (touches every screen)

- `ui/theme/Motion.kt` — motion tokens (durations + playful spring specs) and a
  `rememberReducedMotion()` helper so decorative effects collapse to their final
  state when the OS has animations off.
- `ui/components/BouncyModifiers.kt` — `Modifier.bouncyPress()` (springy scale on
  press) and `Modifier.entrance()` (fade + rise on first composition). Both are
  pure visual transforms and end fully visible, so they never change the
  composable tree that tests assert on.
- `ui/components/AnimatedCounter.kt` — a number that rolls to its value (for score
  reveals); settles on the exact value.
- `ui/components/ConfettiOverlay.kt` — a one-shot in-screen confetti burst.

## Applied now

- **Shared primitives** (`PrimaryButton`, `SecondaryButton`, `SkyjoCard`) — springy
  press feedback + richer depth. These are used on **every screen**, so the whole
  app gains tactile press states and layering.
- **Game Over** — a confetti celebration rains over the results.

The kit is intentionally reusable so per-screen touches (staggered card
entrances, turn spotlight, in-game score roll-ups) can be layered on incrementally
without re-plumbing.

## Testing / verification

- Frontend unit suite green (existing Compose/Robolectric UI tests unchanged and
  passing). New effects are additive or transform-only, and reduced-motion-aware,
  specifically so they don't disturb node/text assertions.
- **Visual note:** these are Compose visuals; they can't be rendered in CI/unit
  tests — please run the app to judge the look and feel. Effects are conservative
  and each is easy to tune or dial back.
